### PR TITLE
Add missing features used in gluon's source mapping

### DIFF
--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -9,6 +9,12 @@ publish = false
 
 [dependencies]
 failure = "0.1.1"
+serde_derive = { version = "1", optional = true }
+serde = { version = "1", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "0.5.0"
+
+
+[features]
+serialization = ["serde", "serde_derive"]

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -145,6 +145,22 @@ impl FileMap {
         self.span
     }
 
+    pub fn offset(&self, line: LineIndex, column: ColumnIndex) -> Option<ByteOffset> {
+        self.line_offset(line).ok().and_then(|mut offset| {
+            offset += ByteOffset::from(column.0 as i64);
+            if offset.to_usize() >= self.src.len() {
+                None
+            } else {
+                Some(offset)
+            }
+        })
+    }
+
+    pub fn byte_index(&self, line: LineIndex, column: ColumnIndex) -> Option<ByteIndex> {
+        self.offset(line, column)
+            .map(|offset| self.span.start() + offset)
+    }
+
     /// Returns the byte offset to the start of `line`
     pub fn line_offset(&self, index: LineIndex) -> Result<ByteOffset, LineIndexError> {
         self.lines

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Cow;
 use std::{fmt, io};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use index::{ByteIndex, ByteOffset, ColumnIndex, LineIndex, LineOffset, RawIndex, RawOffset};
 use span::ByteSpan;
@@ -13,6 +13,30 @@ pub enum FileName {
     Real(PathBuf),
     /// A synthetic file, eg. from the REPL
     Virtual(Cow<'static, str>),
+}
+
+impl From<PathBuf> for FileName {
+    fn from(name: PathBuf) -> FileName {
+        FileName::real(name)
+    }
+}
+
+impl<'a> From<&'a Path> for FileName {
+    fn from(name: &Path) -> FileName {
+        FileName::real(name)
+    }
+}
+
+impl From<String> for FileName {
+    fn from(name: String) -> FileName {
+        FileName::virtual_(name)
+    }
+}
+
+impl From<&'static str> for FileName {
+    fn from(name: &'static str) -> FileName {
+        FileName::virtual_(name)
+    }
 }
 
 impl FileName {

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -68,6 +68,10 @@ pub struct FileMap {
 }
 
 impl FileMap {
+    pub fn anonymous(src: String) -> FileMap {
+        Self::new(FileName::virtual_(""), src, ByteIndex::from(0))
+    }
+
     /// Construct a new filemap, creating an index of line start locations
     pub(crate) fn new(name: FileName, src: String, start: ByteIndex) -> FileMap {
         use std::iter;

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -93,7 +93,7 @@ pub struct FileMap {
 
 impl FileMap {
     pub fn anonymous(src: String) -> FileMap {
-        Self::new(FileName::virtual_(""), src, ByteIndex::from(0))
+        Self::new(FileName::virtual_(""), src, ByteIndex::from(1))
     }
 
     /// Construct a new filemap, creating an index of line start locations

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -1,8 +1,8 @@
 //! Various source mapping utilities
 
 use std::borrow::Cow;
-use std::{fmt, io};
 use std::path::{Path, PathBuf};
+use std::{fmt, io};
 
 use index::{ByteIndex, ByteOffset, ColumnIndex, LineIndex, LineOffset, RawIndex, RawOffset};
 use span::ByteSpan;
@@ -148,7 +148,7 @@ impl FileMap {
     pub fn offset(&self, line: LineIndex, column: ColumnIndex) -> Option<ByteOffset> {
         self.line_offset(line).ok().and_then(|mut offset| {
             offset += ByteOffset::from(column.0 as i64);
-            if offset.to_usize() >= self.src.len() {
+            if offset.to_usize() > self.src.len() {
                 None
             } else {
                 Some(offset)
@@ -293,6 +293,29 @@ mod tests {
                 .map(|i| LineIndex(i as RawIndex))
                 .collect()
         }
+    }
+
+    #[test]
+    fn offset() {
+        let test_data = TestData::new();
+        assert!(
+            test_data
+                .filemap
+                .offset(
+                    (test_data.lines.len() as u32 - 1).into(),
+                    (test_data.lines.last().unwrap().len() as u32).into()
+                )
+                .is_some()
+        );
+        assert!(
+            test_data
+                .filemap
+                .offset(
+                    (test_data.lines.len() as u32 - 1).into(),
+                    (test_data.lines.last().unwrap().len() as u32 + 1).into()
+                )
+                .is_none()
+        );
     }
 
     #[test]

--- a/codespan/src/index.rs
+++ b/codespan/src/index.rs
@@ -293,6 +293,19 @@ where
 
 macro_rules! impl_index {
     ($Index:ident, $Offset:ident) => {
+
+        impl From<RawOffset> for $Offset {
+            fn from(i: RawOffset) -> Self {
+                $Offset(i)
+            }
+        }
+
+        impl From<RawIndex> for $Index {
+            fn from(i: RawIndex) -> Self {
+                $Index(i)
+            }
+        }
+
         impl Offset for $Offset {
             const ZERO: $Offset = $Offset(0);
         }

--- a/codespan/src/index.rs
+++ b/codespan/src/index.rs
@@ -12,6 +12,7 @@ pub type RawOffset = i64;
 
 /// A zero-indexed line offset into a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct LineIndex(pub RawIndex);
 
 impl LineIndex {
@@ -49,6 +50,7 @@ impl fmt::Debug for LineIndex {
 
 /// A 1-indexed line number. Useful for pretty printing source locations.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct LineNumber(RawIndex);
 
 impl fmt::Debug for LineNumber {
@@ -67,6 +69,7 @@ impl fmt::Display for LineNumber {
 
 /// A line offset in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct LineOffset(pub RawOffset);
 
 impl Default for LineOffset {
@@ -91,6 +94,7 @@ impl fmt::Display for LineOffset {
 
 /// A zero-indexed column offset into a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct ColumnIndex(pub RawIndex);
 
 impl ColumnIndex {
@@ -128,6 +132,7 @@ impl fmt::Debug for ColumnIndex {
 
 /// A 1-indexed column number. Useful for pretty printing source locations.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct ColumnNumber(RawIndex);
 
 impl fmt::Debug for ColumnNumber {
@@ -146,6 +151,7 @@ impl fmt::Display for ColumnNumber {
 
 /// A column offset in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct ColumnOffset(pub RawOffset);
 
 impl Default for ColumnOffset {
@@ -170,6 +176,7 @@ impl fmt::Display for ColumnOffset {
 
 /// A byte position in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct ByteIndex(pub RawIndex);
 
 impl ByteIndex {
@@ -206,6 +213,7 @@ impl fmt::Display for ByteIndex {
 
 /// A byte offset in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct ByteOffset(pub RawOffset);
 
 impl ByteOffset {

--- a/codespan/src/lib.rs
+++ b/codespan/src/lib.rs
@@ -7,6 +7,12 @@ extern crate failure;
 #[macro_use]
 extern crate pretty_assertions;
 
+#[cfg(feature = "serde_derive")]
+extern crate serde;
+#[cfg(feature = "serde_derive")]
+#[macro_use]
+extern crate serde_derive;
+
 mod codemap;
 mod filemap;
 mod index;

--- a/codespan/src/span.rs
+++ b/codespan/src/span.rs
@@ -40,6 +40,14 @@ impl<I: Ord> Span<I> {
             }
         }
     }
+
+    pub fn map<F, J>(self, mut f: F) -> Span<J>
+    where
+        F: FnMut(I) -> J,
+        J: Ord,
+    {
+        Span::new(f(self.start), f(self.end))
+    }
 }
 
 impl<I> Span<I> {


### PR DESCRIPTION
PR name is a bit blatant but I have been updating gluon to use codemap instead and found a few things that were missing (compared to the similar structure previously used in gluon). I think most things should be pretty straightforward improvements though naming may need to be changed.

https://github.com/gluon-lang/gluon/pull/505