### PR TITLE
Add colorized output for emit

### DIFF
--- a/codespan-reporting/examples/emit.rs
+++ b/codespan-reporting/examples/emit.rs
@@ -11,23 +11,34 @@ fn main() {
     let source = r##"
 (define test 123)
 (+ test "")
+()
 "##;
     let file_map = code_map.add_filemap("test".into(), source.to_string());
 
     let str_start = file_map.byte_index(2.into(), 8.into()).unwrap();
-    let diagnostic = Diagnostic::new(Severity::Error, "Unexpected type in `+` application")
-        .with_label(
-            Label::new_primary(Span::from_offset(str_start, 2.into()))
-                .with_message("Expected integer but got string"),
-        );
+    let error = Diagnostic::new(Severity::Error, "Unexpected type in `+` application").with_label(
+        Label::new_primary(Span::from_offset(str_start, 2.into()))
+            .with_message("Expected integer but got string"),
+    );
+
+    let line_start = file_map.byte_index(2.into(), 0.into()).unwrap();
+    let warning = Diagnostic::new(
+        Severity::Warning,
+        "`+` function has no effect unless its result is used",
+    ).with_label(Label::new_primary(Span::from_offset(line_start, 11.into())));
+
+    let diagnostics = [error, warning];
 
     let writer = StandardStream::stdout(ColorChoice::Auto);
-
-    emit(&mut writer.lock(), &code_map, &diagnostic).unwrap();
-
-    println!();
+    for diagnostic in &diagnostics {
+        emit(&mut writer.lock(), &code_map, &diagnostic).unwrap();
+        println!();
+    }
 
     let writer = StandardStream::stdout(ColorChoice::Never);
 
-    emit(&mut writer.lock(), &code_map, &diagnostic).unwrap();
+    for diagnostic in &diagnostics {
+        emit(&mut writer.lock(), &code_map, &diagnostic).unwrap();
+        println!();
+    }
 }

--- a/codespan-reporting/examples/emit.rs
+++ b/codespan-reporting/examples/emit.rs
@@ -6,8 +6,6 @@ use codespan_reporting::termcolor::{ColorChoice, StandardStream};
 use codespan_reporting::{emit, Diagnostic, Label, Severity};
 
 fn main() {
-    let writer = StandardStream::stdout(ColorChoice::Auto);
-
     let mut code_map = CodeMap::new();
 
     let source = r##"
@@ -22,5 +20,14 @@ fn main() {
             Label::new_primary(Span::from_offset(str_start, 2.into()))
                 .with_message("Expected integer but got string"),
         );
+
+    let writer = StandardStream::stdout(ColorChoice::Auto);
+
+    emit(&mut writer.lock(), &code_map, &diagnostic).unwrap();
+
+    println!();
+
+    let writer = StandardStream::stdout(ColorChoice::Never);
+
     emit(&mut writer.lock(), &code_map, &diagnostic).unwrap();
 }

--- a/codespan-reporting/examples/emit.rs
+++ b/codespan-reporting/examples/emit.rs
@@ -1,0 +1,25 @@
+extern crate codespan;
+extern crate codespan_reporting;
+
+use codespan::CodeMap;
+use codespan_reporting::termcolor::{ColorChoice, StandardStream};
+use codespan_reporting::{emit, Diagnostic, Label, Severity};
+
+fn main() {
+    let writer = StandardStream::stdout(ColorChoice::Auto);
+
+    let mut code_map = CodeMap::new();
+
+    let source = r##"
+(define test 123)
+(+ test "")
+"##;
+    let file_map = code_map.add_filemap("test".into(), source.to_string());
+
+    let diagnostic = Diagnostic::new(Severity::Error, "Unexpected type in `+` application")
+        .with_label(
+            Label::new_primary(file_map.line_span(2.into()).unwrap())
+                .with_message("Expected integer but got string"),
+        );
+    emit(&mut writer.lock(), &code_map, &diagnostic).unwrap();
+}

--- a/codespan-reporting/examples/emit.rs
+++ b/codespan-reporting/examples/emit.rs
@@ -1,7 +1,7 @@
 extern crate codespan;
 extern crate codespan_reporting;
 
-use codespan::CodeMap;
+use codespan::{CodeMap, Span};
 use codespan_reporting::termcolor::{ColorChoice, StandardStream};
 use codespan_reporting::{emit, Diagnostic, Label, Severity};
 
@@ -16,9 +16,10 @@ fn main() {
 "##;
     let file_map = code_map.add_filemap("test".into(), source.to_string());
 
+    let str_start = file_map.byte_index(2.into(), 8.into()).unwrap();
     let diagnostic = Diagnostic::new(Severity::Error, "Unexpected type in `+` application")
         .with_label(
-            Label::new_primary(file_map.line_span(2.into()).unwrap())
+            Label::new_primary(Span::from_offset(str_start, 2.into()))
                 .with_message("Expected integer but got string"),
         );
     emit(&mut writer.lock(), &code_map, &diagnostic).unwrap();

--- a/codespan-reporting/src/diagnostic.rs
+++ b/codespan-reporting/src/diagnostic.rs
@@ -38,7 +38,7 @@ impl Label {
     }
 
     pub fn new_secondary(span: ByteSpan) -> Label {
-        Label::new(span, LabelStyle::Primary)
+        Label::new(span, LabelStyle::Secondary)
     }
 
     pub fn with_message<S: Into<String>>(mut self, message: S) -> Label {

--- a/codespan-reporting/src/emitter.rs
+++ b/codespan-reporting/src/emitter.rs
@@ -1,23 +1,40 @@
+use std::io;
+
 use codespan::CodeMap;
+
+use termcolor::{ColorSpec, WriteColor};
 
 use Diagnostic;
 
-pub fn emit(codemap: &CodeMap, diagnostic: &Diagnostic) {
-    println!("{}: {}", diagnostic.severity, diagnostic.message);
+pub fn emit<W>(mut writer: W, codemap: &CodeMap, diagnostic: &Diagnostic) -> io::Result<()>
+where
+    W: WriteColor,
+{
+    writer.set_color(ColorSpec::new().set_fg(Some(diagnostic.severity.color())))?;
+    write!(writer, "{}", diagnostic.severity)?;
+    writer.reset()?;
+    writeln!(writer, ": {}", diagnostic.message)?;
     for label in &diagnostic.labels {
         match codemap.find_file(label.span.start()) {
             None => if let Some(ref message) = label.message {
-                println!("- {}", message)
+                writeln!(writer, "- {}", message)?
             },
             Some(file) => {
                 let (line, col) = file.location(label.span.start()).expect("location");
 
-                print!("- {}:{}:{}", file.name(), line.number(), col.number());
+                writeln!(
+                    writer,
+                    "- {}:{}:{}",
+                    file.name(),
+                    line.number(),
+                    col.number()
+                )?;
                 match label.message {
-                    None => println!(),
-                    Some(ref label) => println!(": {}", label),
+                    None => writeln!(writer)?,
+                    Some(ref label) => writeln!(writer, ": {}", label)?,
                 }
             },
         }
     }
+    Ok(())
 }

--- a/codespan-reporting/src/emitter.rs
+++ b/codespan-reporting/src/emitter.rs
@@ -11,8 +11,12 @@ where
     W: WriteColor,
 {
     let supports_color = writer.supports_color();
+    let line_location_color = ColorSpec::new().set_fg(Some(Color::Cyan)).clone();
+    let diagnostic_color = ColorSpec::new()
+        .set_fg(Some(diagnostic.severity.color()))
+        .clone();
 
-    writer.set_color(ColorSpec::new().set_fg(Some(diagnostic.severity.color())))?;
+    writer.set_color(&diagnostic_color)?;
     write!(writer, "{}", diagnostic.severity)?;
     writer.reset()?;
     writeln!(writer, ": {}", diagnostic.message)?;
@@ -37,33 +41,49 @@ where
                     .expect("line_prefix");
                 let line_marked = file.src_slice(label.span).expect("line_marked");
                 let line_suffix = file.src_slice(line_span.with_start(label.span.end()))
-                    .expect("line_suffix");
+                    .expect("line_suffix")
+                    .trim_right_matches(|c: char| c == '\r' || c == '\n');
 
-                writer.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)))?;
-                let line_location_prefix = format!("{} | ", line.number());
-                write!(writer, "{}", line_location_prefix)?;
+                writer.set_color(&line_location_color)?;
+                let line_string = line.number().to_string();
+                let line_location_prefix = format!("{:prefix$} | ", "", prefix = line_string.len());
+                write!(writer, "{} | ", line_string)?;
                 writer.reset()?;
 
                 write!(writer, "{}", line_prefix)?;
-                writer.set_color(ColorSpec::new().set_fg(Some(Color::Red)))?;
+                writer.set_color(&diagnostic_color)?;
                 write!(writer, "{}", line_marked)?;
                 writer.reset()?;
-                write!(writer, "{}", line_suffix)?;
+                writeln!(writer, "{}", line_suffix)?;
 
-                if !supports_color {
-                    writeln!(
+                if !supports_color || label.message.is_some() {
+                    writer.set_color(&line_location_color)?;
+                    write!(writer, "{}", line_location_prefix)?;
+                    writer.reset()?;
+
+                    writer.set_color(&diagnostic_color)?;
+                    write!(
                         writer,
                         "{:prefix$}{:^>marked$}",
                         "",
                         "",
-                        prefix = line_location_prefix.len() + line_prefix.len(),
+                        prefix = line_prefix.len(),
                         marked = line_marked.len()
                     )?;
+                    writer.reset()?;
+
+                    if label.message.is_none() {
+                        writeln!(writer)?;
+                    }
                 }
 
                 match label.message {
-                    None => writeln!(writer)?,
-                    Some(ref label) => writeln!(writer, ": {}", label)?,
+                    None => (),
+                    Some(ref label) => {
+                        writer.set_color(&diagnostic_color)?;
+                        writeln!(writer, " {}", label)?;
+                        writer.reset()?;
+                    },
                 }
             },
         }

--- a/codespan-reporting/src/lib.rs
+++ b/codespan-reporting/src/lib.rs
@@ -1,5 +1,5 @@
 extern crate codespan;
-extern crate termcolor;
+pub extern crate termcolor;
 
 use std::cmp::Ordering;
 use std::fmt;

--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -9,6 +9,12 @@ publish = false
 
 [dependencies]
 failure = "0.1.1"
+serde_derive = { version = "1", optional = true }
+serde = { version = "1", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "0.5.0"
+
+
+[features]
+serialization = ["serde", "serde_derive"]

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -145,6 +145,22 @@ impl FileMap {
         self.span
     }
 
+    pub fn offset(&self, line: LineIndex, column: ColumnIndex) -> Option<ByteOffset> {
+        self.line_offset(line).ok().and_then(|mut offset| {
+            offset += ByteOffset::from(column.0 as i64);
+            if offset.to_usize() >= self.src.len() {
+                None
+            } else {
+                Some(offset)
+            }
+        })
+    }
+
+    pub fn byte_index(&self, line: LineIndex, column: ColumnIndex) -> Option<ByteIndex> {
+        self.offset(line, column)
+            .map(|offset| self.span.start() + offset)
+    }
+
     /// Returns the byte offset to the start of `line`
     pub fn line_offset(&self, index: LineIndex) -> Result<ByteOffset, LineIndexError> {
         self.lines

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Cow;
 use std::{fmt, io};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use index::{ByteIndex, ByteOffset, ColumnIndex, LineIndex, LineOffset, RawIndex, RawOffset};
 use span::ByteSpan;
@@ -13,6 +13,30 @@ pub enum FileName {
     Real(PathBuf),
     /// A synthetic file, eg. from the REPL
     Virtual(Cow<'static, str>),
+}
+
+impl From<PathBuf> for FileName {
+    fn from(name: PathBuf) -> FileName {
+        FileName::real(name)
+    }
+}
+
+impl<'a> From<&'a Path> for FileName {
+    fn from(name: &Path) -> FileName {
+        FileName::real(name)
+    }
+}
+
+impl From<String> for FileName {
+    fn from(name: String) -> FileName {
+        FileName::virtual_(name)
+    }
+}
+
+impl From<&'static str> for FileName {
+    fn from(name: &'static str) -> FileName {
+        FileName::virtual_(name)
+    }
 }
 
 impl FileName {

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -68,6 +68,10 @@ pub struct FileMap {
 }
 
 impl FileMap {
+    pub fn anonymous(src: String) -> FileMap {
+        Self::new(FileName::virtual_(""), src, ByteIndex::from(0))
+    }
+
     /// Construct a new filemap, creating an index of line start locations
     pub(crate) fn new(name: FileName, src: String, start: ByteIndex) -> FileMap {
         use std::iter;

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -93,7 +93,7 @@ pub struct FileMap {
 
 impl FileMap {
     pub fn anonymous(src: String) -> FileMap {
-        Self::new(FileName::virtual_(""), src, ByteIndex::from(0))
+        Self::new(FileName::virtual_(""), src, ByteIndex::from(1))
     }
 
     /// Construct a new filemap, creating an index of line start locations

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -103,12 +103,8 @@ pub struct FileMap {
 }
 
 impl FileMap {
-    pub fn anonymous(src: String) -> FileMap {
-        Self::new(FileName::virtual_(""), src, ByteIndex::from(1))
-    }
-
     /// Construct a new filemap, creating an index of line start locations
-    pub(crate) fn new(name: FileName, src: String, start: ByteIndex) -> FileMap {
+    pub fn new(name: FileName, src: String, start: ByteIndex) -> FileMap {
         use std::iter;
 
         let span = ByteSpan::from_offset(start, ByteOffset::from_str(&src));

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -1,8 +1,8 @@
 //! Various source mapping utilities
 
 use std::borrow::Cow;
-use std::{fmt, io};
 use std::path::{Path, PathBuf};
+use std::{fmt, io};
 
 use index::{ByteIndex, ByteOffset, ColumnIndex, LineIndex, LineOffset, RawIndex, RawOffset};
 use span::ByteSpan;
@@ -148,7 +148,7 @@ impl FileMap {
     pub fn offset(&self, line: LineIndex, column: ColumnIndex) -> Option<ByteOffset> {
         self.line_offset(line).ok().and_then(|mut offset| {
             offset += ByteOffset::from(column.0 as i64);
-            if offset.to_usize() >= self.src.len() {
+            if offset.to_usize() > self.src.len() {
                 None
             } else {
                 Some(offset)
@@ -293,6 +293,29 @@ mod tests {
                 .map(|i| LineIndex(i as RawIndex))
                 .collect()
         }
+    }
+
+    #[test]
+    fn offset() {
+        let test_data = TestData::new();
+        assert!(
+            test_data
+                .filemap
+                .offset(
+                    (test_data.lines.len() as u32 - 1).into(),
+                    (test_data.lines.last().unwrap().len() as u32).into()
+                )
+                .is_some()
+        );
+        assert!(
+            test_data
+                .filemap
+                .offset(
+                    (test_data.lines.len() as u32 - 1).into(),
+                    (test_data.lines.last().unwrap().len() as u32 + 1).into()
+                )
+                .is_none()
+        );
     }
 
     #[test]

--- a/codespan/src/index.rs
+++ b/codespan/src/index.rs
@@ -293,6 +293,19 @@ where
 
 macro_rules! impl_index {
     ($Index:ident, $Offset:ident) => {
+
+        impl From<RawOffset> for $Offset {
+            fn from(i: RawOffset) -> Self {
+                $Offset(i)
+            }
+        }
+
+        impl From<RawIndex> for $Index {
+            fn from(i: RawIndex) -> Self {
+                $Index(i)
+            }
+        }
+
         impl Offset for $Offset {
             const ZERO: $Offset = $Offset(0);
         }

--- a/codespan/src/index.rs
+++ b/codespan/src/index.rs
@@ -12,6 +12,7 @@ pub type RawOffset = i64;
 
 /// A zero-indexed line offset into a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct LineIndex(pub RawIndex);
 
 impl LineIndex {
@@ -49,6 +50,7 @@ impl fmt::Debug for LineIndex {
 
 /// A 1-indexed line number. Useful for pretty printing source locations.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct LineNumber(RawIndex);
 
 impl fmt::Debug for LineNumber {
@@ -67,6 +69,7 @@ impl fmt::Display for LineNumber {
 
 /// A line offset in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct LineOffset(pub RawOffset);
 
 impl Default for LineOffset {
@@ -91,6 +94,7 @@ impl fmt::Display for LineOffset {
 
 /// A zero-indexed column offset into a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct ColumnIndex(pub RawIndex);
 
 impl ColumnIndex {
@@ -128,6 +132,7 @@ impl fmt::Debug for ColumnIndex {
 
 /// A 1-indexed column number. Useful for pretty printing source locations.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct ColumnNumber(RawIndex);
 
 impl fmt::Debug for ColumnNumber {
@@ -146,6 +151,7 @@ impl fmt::Display for ColumnNumber {
 
 /// A column offset in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct ColumnOffset(pub RawOffset);
 
 impl Default for ColumnOffset {
@@ -170,6 +176,7 @@ impl fmt::Display for ColumnOffset {
 
 /// A byte position in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct ByteIndex(pub RawIndex);
 
 impl ByteIndex {
@@ -206,6 +213,7 @@ impl fmt::Display for ByteIndex {
 
 /// A byte offset in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct ByteOffset(pub RawOffset);
 
 impl ByteOffset {

--- a/codespan/src/lib.rs
+++ b/codespan/src/lib.rs
@@ -7,6 +7,12 @@ extern crate failure;
 #[macro_use]
 extern crate pretty_assertions;
 
+#[cfg(feature = "serde_derive")]
+extern crate serde;
+#[cfg(feature = "serde_derive")]
+#[macro_use]
+extern crate serde_derive;
+
 mod codemap;
 mod filemap;
 mod index;

--- a/codespan/src/span.rs
+++ b/codespan/src/span.rs
@@ -1,5 +1,5 @@
-use std::{cmp, fmt};
 use std::cmp::Ordering;
+use std::{cmp, fmt};
 
 use index::{ByteIndex, Index};
 
@@ -84,11 +84,11 @@ impl<I: Index> Span<I> {
     /// use codespan::{ByteIndex, Span};
     ///
     /// let span = Span::new(ByteIndex(3), ByteIndex(6));
-    /// assert_eq!(span.with_lo(ByteIndex(2)), Span::new(ByteIndex(2), ByteIndex(6)));
-    /// assert_eq!(span.with_lo(ByteIndex(5)), Span::new(ByteIndex(5), ByteIndex(6)));
-    /// assert_eq!(span.with_lo(ByteIndex(7)), Span::new(ByteIndex(6), ByteIndex(7)));
+    /// assert_eq!(span.with_start(ByteIndex(2)), Span::new(ByteIndex(2), ByteIndex(6)));
+    /// assert_eq!(span.with_start(ByteIndex(5)), Span::new(ByteIndex(5), ByteIndex(6)));
+    /// assert_eq!(span.with_start(ByteIndex(7)), Span::new(ByteIndex(6), ByteIndex(7)));
     /// ```
-    pub fn with_lo(self, start: I) -> Span<I> {
+    pub fn with_start(self, start: I) -> Span<I> {
         Span::new(start, self.end())
     }
 
@@ -98,11 +98,11 @@ impl<I: Index> Span<I> {
     /// use codespan::{ByteIndex, Span};
     ///
     /// let span = Span::new(ByteIndex(3), ByteIndex(6));
-    /// assert_eq!(span.with_hi(ByteIndex(7)), Span::new(ByteIndex(3), ByteIndex(7)));
-    /// assert_eq!(span.with_hi(ByteIndex(5)), Span::new(ByteIndex(3), ByteIndex(5)));
-    /// assert_eq!(span.with_hi(ByteIndex(2)), Span::new(ByteIndex(2), ByteIndex(3)));
+    /// assert_eq!(span.with_end(ByteIndex(7)), Span::new(ByteIndex(3), ByteIndex(7)));
+    /// assert_eq!(span.with_end(ByteIndex(5)), Span::new(ByteIndex(3), ByteIndex(5)));
+    /// assert_eq!(span.with_end(ByteIndex(2)), Span::new(ByteIndex(2), ByteIndex(3)));
     /// ```
-    pub fn with_hi(self, end: I) -> Span<I> {
+    pub fn with_end(self, end: I) -> Span<I> {
         Span::new(self.start(), end)
     }
 

--- a/codespan/src/span.rs
+++ b/codespan/src/span.rs
@@ -40,6 +40,14 @@ impl<I: Ord> Span<I> {
             }
         }
     }
+
+    pub fn map<F, J>(self, mut f: F) -> Span<J>
+    where
+        F: FnMut(I) -> J,
+        J: Ord,
+    {
+        Span::new(f(self.start), f(self.end))
+    }
 }
 
 impl<I> Span<I> {


### PR DESCRIPTION
<img width="470" alt="codespan" src="https://user-images.githubusercontent.com/957312/38644401-a649cc40-3de0-11e8-9f2b-d25a46e9d8e4.png">

I haven't spent to much time on this but but I think this should serve as a starting point for #1 (or at least a start/continuation of discussion on it). I would like to get something like this in in any case so that I don't lose out on the source display part in https://github.com/gluon-lang/gluon/pull/505 :)