### PR TITLE
Hide the ByteIndex parameter for FileMap in the public API

### DIFF
--- a/codespan/src/codemap.rs
+++ b/codespan/src/codemap.rs
@@ -29,7 +29,7 @@ impl CodeMap {
 
     /// Adds a filemap to the codemap with the given name and source string
     pub fn add_filemap(&mut self, name: FileName, src: String) -> Arc<FileMap> {
-        let file = Arc::new(FileMap::new(name, src, self.next_start_index()));
+        let file = Arc::new(FileMap::with_index(name, src, self.next_start_index()));
         self.files.push(file.clone());
         file
     }

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -103,8 +103,13 @@ pub struct FileMap {
 }
 
 impl FileMap {
-    /// Construct a new filemap, creating an index of line start locations
-    pub fn new(name: FileName, src: String, start: ByteIndex) -> FileMap {
+    /// Construct a new, standalone filemap. Can be usefol for tests which consists of a single
+    /// source file
+    pub fn new(name: FileName, src: String) -> FileMap {
+        FileMap::with_index(name, src, ByteIndex(1))
+    }
+
+    pub(crate) fn with_index(name: FileName, src: String, start: ByteIndex) -> FileMap {
         use std::iter;
 
         let span = ByteSpan::from_offset(start, ByteOffset::from_str(&src));
@@ -134,7 +139,7 @@ impl FileMap {
         let mut src = String::new();
         file.read_to_string(&mut src)?;
 
-        Ok(FileMap::new(FileName::Real(name), src, start))
+        Ok(FileMap::with_index(FileName::Real(name), src, start))
     }
 
     /// The name of the file that the source came from

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -103,8 +103,10 @@ pub struct FileMap {
 }
 
 impl FileMap {
-    /// Construct a new, standalone filemap. Can be usefol for tests which consists of a single
-    /// source file
+    /// Construct a new, standalone filemap.
+    ///
+    /// This can be useful for tests that consist of a single source file. Production code should however 
+    /// use `CodeMap::add_filemap` or `CodeMap::add_filemap_from_disk` instead.
     pub fn new(name: FileName, src: String) -> FileMap {
         FileMap::with_index(name, src, ByteIndex(1))
     }


### PR DESCRIPTION
It is not clear that 0 is not a valid index and it is probably not useful for external users to create FileMap with non-1 indexes without CodeMap.