### PR TITLE
Add some missing impls

### DIFF
--- a/codespan/src/codemap.rs
+++ b/codespan/src/codemap.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use filemap::{FileMap, FileName};
 use index::{ByteIndex, ByteOffset};
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CodeMap {
     files: Vec<Arc<FileMap>>,
 }

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -7,7 +7,7 @@ use std::{fmt, io};
 use index::{ByteIndex, ByteOffset, ColumnIndex, LineIndex, LineOffset, RawIndex, RawOffset};
 use span::ByteSpan;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub enum FileName {
     /// A real file on disk
     Real(PathBuf),
@@ -105,7 +105,7 @@ pub struct FileMap {
 impl FileMap {
     /// Construct a new, standalone filemap.
     ///
-    /// This can be useful for tests that consist of a single source file. Production code should however 
+    /// This can be useful for tests that consist of a single source file. Production code should however
     /// use `CodeMap::add_filemap` or `CodeMap::add_filemap_from_disk` instead.
     pub fn new(name: FileName, src: String) -> FileMap {
         FileMap::with_index(name, src, ByteIndex(1))


### PR DESCRIPTION
For the `Clone` bound, I want to be able to store a `CodeMap` inside some of my error types so that they can implement `fmt::Display` and still print out the source positions.