### PR TITLE
Fix marker padding

### DIFF
--- a/codespan-reporting/Cargo.toml
+++ b/codespan-reporting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codespan-reporting"
-version = "0.1.1"
+version = "0.1.2"
 readme = "README.md"
 license = "Apache-2.0"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>"]

--- a/codespan-reporting/examples/emit.rs
+++ b/codespan-reporting/examples/emit.rs
@@ -16,10 +16,15 @@ fn main() {
     let file_map = code_map.add_filemap("test".into(), source.to_string());
 
     let str_start = file_map.byte_index(2.into(), 8.into()).unwrap();
-    let error = Diagnostic::new(Severity::Error, "Unexpected type in `+` application").with_label(
-        Label::new_primary(Span::from_offset(str_start, 2.into()))
-            .with_message("Expected integer but got string"),
-    );
+    let error = Diagnostic::new(Severity::Error, "Unexpected type in `+` application")
+        .with_label(
+            Label::new_primary(Span::from_offset(str_start, 2.into()))
+                .with_message("Expected integer but got string"),
+        )
+        .with_label(
+            Label::new_secondary(Span::from_offset(str_start, 2.into()))
+                .with_message("Expected integer but got string"),
+        );
 
     let line_start = file_map.byte_index(2.into(), 0.into()).unwrap();
     let warning = Diagnostic::new(

--- a/codespan-reporting/src/emitter.rs
+++ b/codespan-reporting/src/emitter.rs
@@ -1,10 +1,19 @@
-use std::io;
-
 use codespan::CodeMap;
-
+use std::{fmt, io};
 use termcolor::{Color, ColorSpec, WriteColor};
 
 use Diagnostic;
+
+struct Pad<T>(T, usize);
+
+impl<T: fmt::Display> fmt::Display for Pad<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for _ in 0..(self.1) {
+            self.0.fmt(f)?;
+        }
+        Ok(())
+    }
+}
 
 pub fn emit<W>(mut writer: W, codemap: &CodeMap, diagnostic: &Diagnostic) -> io::Result<()>
 where
@@ -46,7 +55,7 @@ where
 
                 writer.set_color(&line_location_color)?;
                 let line_string = line.number().to_string();
-                let line_location_prefix = format!("{:prefix$} | ", "", prefix = line_string.len());
+                let line_location_prefix = format!("{} | ", Pad(' ', line_string.len()));
                 write!(writer, "{} | ", line_string)?;
                 writer.reset()?;
 
@@ -64,9 +73,9 @@ where
                     writer.set_color(&diagnostic_color)?;
                     write!(
                         writer,
-                        "{:prefix$}{:^>marked$}",
-                        prefix = line_prefix.len(),
-                        marked = line_marked.len()
+                        "{}{}",
+                        Pad(' ', line_prefix.len()),
+                        Pad('^', line_marked.len()),
                     )?;
                     writer.reset()?;
 

--- a/codespan-reporting/src/emitter.rs
+++ b/codespan-reporting/src/emitter.rs
@@ -2,7 +2,7 @@ use codespan::CodeMap;
 use std::{fmt, io};
 use termcolor::{Color, ColorSpec, WriteColor};
 
-use Diagnostic;
+use {Diagnostic, LabelStyle};
 
 struct Pad<T>(T, usize);
 
@@ -20,7 +20,7 @@ where
     W: WriteColor,
 {
     let supports_color = writer.supports_color();
-    let line_location_color = ColorSpec::new().set_fg(Some(Color::Cyan)).clone();
+    let line_location_color = ColorSpec::new().set_fg(Some(Color::Blue)).clone();
     let diagnostic_color = ColorSpec::new()
         .set_fg(Some(diagnostic.severity.color()))
         .clone();
@@ -35,13 +35,13 @@ where
                 writeln!(writer, "- {}", message)?
             },
             Some(file) => {
-                let (line, col) = file.location(label.span.start()).expect("location");
+                let (line, column) = file.location(label.span.start()).expect("location");
                 writeln!(
                     writer,
-                    "- {}:{}:{}",
-                    file.name(),
-                    line.number(),
-                    col.number()
+                    "- {file}:{line}:{column}",
+                    file = file.name(),
+                    line = line.number(),
+                    column = column.number(),
                 )?;
 
                 let line_span = file.line_span(line).expect("line_span");
@@ -51,7 +51,16 @@ where
                 let line_marked = file.src_slice(label.span).expect("line_marked");
                 let line_suffix = file.src_slice(line_span.with_start(label.span.end()))
                     .expect("line_suffix")
-                    .trim_right_matches(|c: char| c == '\r' || c == '\n');
+                    .trim_right_matches(|ch: char| ch == '\r' || ch == '\n');
+
+                let mark = match label.style {
+                    LabelStyle::Primary => '^',
+                    LabelStyle::Secondary => '-',
+                };
+                let label_color = match label.style {
+                    LabelStyle::Primary => diagnostic_color.clone(),
+                    LabelStyle::Secondary => ColorSpec::new().set_fg(Some(Color::Blue)).clone(),
+                };
 
                 writer.set_color(&line_location_color)?;
                 let line_string = line.number().to_string();
@@ -60,7 +69,7 @@ where
                 writer.reset()?;
 
                 write!(writer, "{}", line_prefix)?;
-                writer.set_color(&diagnostic_color)?;
+                writer.set_color(&label_color)?;
                 write!(writer, "{}", line_marked)?;
                 writer.reset()?;
                 writeln!(writer, "{}", line_suffix)?;
@@ -70,12 +79,12 @@ where
                     write!(writer, "{}", line_location_prefix)?;
                     writer.reset()?;
 
-                    writer.set_color(&diagnostic_color)?;
+                    writer.set_color(&label_color)?;
                     write!(
                         writer,
                         "{}{}",
                         Pad(' ', line_prefix.len()),
-                        Pad('^', line_marked.len()),
+                        Pad(mark, line_marked.len()),
                     )?;
                     writer.reset()?;
 
@@ -87,7 +96,7 @@ where
                 match label.message {
                     None => (),
                     Some(ref label) => {
-                        writer.set_color(&diagnostic_color)?;
+                        writer.set_color(&label_color)?;
                         writeln!(writer, " {}", label)?;
                         writer.reset()?;
                     },


### PR DESCRIPTION
I broke the padding in c1a382ef6e6ddb9bbd8d0f338e5887fdb7b7d2ed due to my misunderstanding of what was going on. I've created a new `Pad` datatype to make it clearer. 

Following rustc's lead I've also:

- made the secondary labels use a different styling to the primary labels, 
- used blue coloring rather than cyan for the line numbers 