### PR TITLE
Make the colors more visible on Windows

### DIFF
--- a/codespan-reporting/src/emitter.rs
+++ b/codespan-reporting/src/emitter.rs
@@ -20,7 +20,10 @@ where
     W: WriteColor,
 {
     let supports_color = writer.supports_color();
-    let line_location_color = ColorSpec::new().set_fg(Some(Color::Blue)).clone();
+    let line_location_color = ColorSpec::new()
+        // Blue is really difficult to see on the standard windows command line
+        .set_fg(Some(if cfg!(windows) { Color::Cyan } else { Color::Blue }))
+        .clone();
     let diagnostic_color = ColorSpec::new()
         .set_fg(Some(diagnostic.severity.color()))
         .clone();
@@ -59,7 +62,13 @@ where
                 };
                 let label_color = match label.style {
                     LabelStyle::Primary => diagnostic_color.clone(),
-                    LabelStyle::Secondary => ColorSpec::new().set_fg(Some(Color::Blue)).clone(),
+                    LabelStyle::Secondary => ColorSpec::new()
+                        .set_fg(Some(if cfg!(windows) {
+                            Color::Cyan
+                        } else {
+                            Color::Blue
+                        }))
+                        .clone(),
                 };
 
                 writer.set_color(&line_location_color)?;
@@ -99,9 +108,9 @@ where
                         writer.set_color(&label_color)?;
                         writeln!(writer, " {}", label)?;
                         writer.reset()?;
-                    },
+                    }
                 }
-            },
+            }
         }
     }
     Ok(())

--- a/codespan-reporting/src/emitter.rs
+++ b/codespan-reporting/src/emitter.rs
@@ -28,10 +28,16 @@ where
         .set_fg(Some(diagnostic.severity.color()))
         .clone();
 
+    let highlight_color = ColorSpec::new().set_bold(true).set_intense(true).clone();
+
     writer.set_color(&diagnostic_color)?;
     write!(writer, "{}", diagnostic.severity)?;
     writer.reset()?;
-    writeln!(writer, ": {}", diagnostic.message)?;
+    write!(writer, ":")?;
+    writer.set_color(&highlight_color)?;
+    writeln!(writer, " {}", diagnostic.message)?;
+    writer.reset()?;
+
     for label in &diagnostic.labels {
         match codemap.find_file(label.span.start()) {
             None => if let Some(ref message) = label.message {


### PR DESCRIPTION
I haven't looked at how this looks on unix so it may be that unix should only have `bold` and not `intense` enabled. Windows required `intense` since it does not understand bold.

Closes #15
 
<img width="662" alt="capture" src="https://user-images.githubusercontent.com/957312/38838888-9314b670-41d8-11e8-8294-2c08d5f73246.PNG">
