### PR TITLE
Implement serialization for more types

### DIFF
--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -20,4 +20,4 @@ pretty_assertions = "0.5.0"
 
 
 [features]
-serialization = ["serde", "serde_derive"]
+serialization = ["serde", "serde/rc", "serde_derive"]

--- a/codespan/src/codemap.rs
+++ b/codespan/src/codemap.rs
@@ -8,6 +8,7 @@ use filemap::{FileMap, FileName};
 use index::{ByteIndex, ByteOffset, RawIndex};
 
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub struct CodeMap {
     files: Vec<Arc<FileMap>>,
 }

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -8,6 +8,7 @@ use index::{ByteIndex, ByteOffset, ColumnIndex, LineIndex, LineOffset, RawIndex,
 use span::ByteSpan;
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub enum FileName {
     /// A real file on disk
     Real(PathBuf),
@@ -90,6 +91,7 @@ pub enum SpanError {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 /// Some source code
 pub struct FileMap<S = String> {
     /// The name of the file that the source came from

--- a/codespan/src/index.rs
+++ b/codespan/src/index.rs
@@ -12,7 +12,7 @@ pub type RawOffset = i64;
 
 /// A zero-indexed line offset into a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub struct LineIndex(pub RawIndex);
 
 impl LineIndex {
@@ -50,7 +50,7 @@ impl fmt::Debug for LineIndex {
 
 /// A 1-indexed line number. Useful for pretty printing source locations.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub struct LineNumber(RawIndex);
 
 impl fmt::Debug for LineNumber {
@@ -69,7 +69,7 @@ impl fmt::Display for LineNumber {
 
 /// A line offset in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub struct LineOffset(pub RawOffset);
 
 impl Default for LineOffset {
@@ -94,7 +94,7 @@ impl fmt::Display for LineOffset {
 
 /// A zero-indexed column offset into a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub struct ColumnIndex(pub RawIndex);
 
 impl ColumnIndex {
@@ -132,7 +132,7 @@ impl fmt::Debug for ColumnIndex {
 
 /// A 1-indexed column number. Useful for pretty printing source locations.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub struct ColumnNumber(RawIndex);
 
 impl fmt::Debug for ColumnNumber {
@@ -151,7 +151,7 @@ impl fmt::Display for ColumnNumber {
 
 /// A column offset in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub struct ColumnOffset(pub RawOffset);
 
 impl Default for ColumnOffset {
@@ -176,7 +176,7 @@ impl fmt::Display for ColumnOffset {
 
 /// A byte position in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub struct ByteIndex(pub RawIndex);
 
 impl ByteIndex {
@@ -213,7 +213,7 @@ impl fmt::Display for ByteIndex {
 
 /// A byte offset in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub struct ByteOffset(pub RawOffset);
 
 impl ByteOffset {

--- a/codespan/src/lib.rs
+++ b/codespan/src/lib.rs
@@ -1,5 +1,13 @@
 //! Utilities for working with source code and printing nicely formatted
 //! diagnostic information like warnings and errors.
+//!
+//! # Optional Features
+//!
+//! Extra functionality is accessible by enabling feature flags. The features
+//! currently available are:
+//!
+//! - **serialization** - Adds `Serialize` and `Deserialize` implementations
+//!   for use with `serde`
 
 #[macro_use]
 extern crate failure;

--- a/codespan/src/lib.rs
+++ b/codespan/src/lib.rs
@@ -8,9 +8,9 @@ extern crate itertools;
 #[macro_use]
 extern crate pretty_assertions;
 
-#[cfg(feature = "serde_derive")]
+#[cfg(feature = "serialization")]
 extern crate serde;
-#[cfg(feature = "serde_derive")]
+#[cfg(feature = "serialization")]
 #[macro_use]
 extern crate serde_derive;
 

--- a/codespan/src/span.rs
+++ b/codespan/src/span.rs
@@ -5,6 +5,7 @@ use index::{ByteIndex, Index};
 
 /// A region of code in a source file
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub struct Span<I> {
     start: I,
     end: I,


### PR DESCRIPTION
I recently tried to serialize things like `Span` and `CodeMap` using serde and found it didn't work. This PR just adds extra impls hidden behind the `serialization` feature flag and fixes a typo where `#[cfg_attr(...)]` above `extern crate serde` was using the wrong feature name.

I also added a note about optional features in the docs to aid in discoverability.