### PR TITLE
Bump codespan to 0.1.2

### DIFF
--- a/codespan-lsp/Cargo.toml
+++ b/codespan-lsp/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/brendanzab/codespan"
 documentation = "https://docs.rs/codespan-lsp"
 
 [dependencies]
-codespan = { version = "0.1", path = "../codespan" }
+codespan = { version = "0.1.2", path = "../codespan" }
 codespan-reporting = { version = "0.1", path = "../codespan-reporting/" }
 
 failure = "0.1"

--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codespan"
-version = "0.1.1"
+version = "0.1.2"
 readme = "../README.md"
 license = "Apache-2.0"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>"]


### PR DESCRIPTION
`codespan-lsp` needs some changes from this but it can otherwise be released as just 0.1