### PR TITLE
Add support for specifiyng an error code with a Diagnostic

### DIFF
--- a/codespan-reporting/examples/emit.rs
+++ b/codespan-reporting/examples/emit.rs
@@ -42,7 +42,8 @@ fn main() {
         .with_label(
             Label::new_secondary(Span::from_offset(str_start, 2.into()))
                 .with_message("Expected integer but got string"),
-        );
+        )
+        .with_code("E0001");
 
     let line_start = file_map.byte_index(2.into(), 0.into()).unwrap();
     let warning = Diagnostic::new(

--- a/codespan-reporting/src/diagnostic.rs
+++ b/codespan-reporting/src/diagnostic.rs
@@ -52,6 +52,8 @@ impl Label {
 pub struct Diagnostic {
     /// The overall severity of the diagnostic
     pub severity: Severity,
+    /// An optional code that identifies this diagnostic.
+    pub code: Option<String>,
     /// The main message associated with this diagnostic
     pub message: String,
     /// The labelled spans marking the regions of code that cause this
@@ -63,6 +65,7 @@ impl Diagnostic {
     pub fn new<S: Into<String>>(severity: Severity, message: S) -> Diagnostic {
         Diagnostic {
             severity,
+            code: None,
             message: message.into(),
             labels: Vec::new(),
         }
@@ -86,6 +89,11 @@ impl Diagnostic {
 
     pub fn new_help<S: Into<String>>(message: S) -> Diagnostic {
         Diagnostic::new(Severity::Help, message)
+    }
+
+    pub fn with_code<S: Into<String>>(mut self, code: S) -> Diagnostic {
+        self.code = Some(code.into());
+        self
     }
 
     pub fn with_label(mut self, label: Label) -> Diagnostic {

--- a/codespan-reporting/src/emitter.rs
+++ b/codespan-reporting/src/emitter.rs
@@ -34,6 +34,11 @@ where
         .clone()
         .set_fg(Some(diagnostic.severity.color())))?;
     write!(writer, "{}", diagnostic.severity)?;
+
+    if let Some(ref code) = diagnostic.code {
+        write!(writer, "[{}]", code)?;
+    }
+
     writer.set_color(&highlight_color)?;
     writeln!(writer, ": {}", diagnostic.message)?;
     writer.reset()?;


### PR DESCRIPTION
Small change to codespan-reporting that adds a new `code` field to the `Diagnostic` struct.  It is emitted in the same style as the Rust compiler.