### PR TITLE
Implement Heapsize calculations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: rust
 cache: cargo
 
 rust:
-- stable
-- beta
-- nightly
+  - stable
+  - beta
+  - nightly
 
 env:
   - CARGO_FEATURES=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,11 @@ rust:
 
 env:
   - CARGO_FEATURES=""
-  - CARGO_FEATURES="memory_usage"
+    REPORTING_CARGO_FEATURES=""
+  - CARGO_FEATURES="memory_usage" 
+    REPORTING_CARGO_FEATURES="memory_usage"
   - CARGO_FEATURES="serialization"
+    REPORTING_CARGO_FEATURES=""
 
 matrix:
   allow_failures:
@@ -28,5 +31,5 @@ script:
   - cargo build --manifest-path=codespan-lsp/Cargo.toml --verbose
   - cargo test --manifest-path=codespan-lsp/Cargo.toml --verbose
   # codespan-reporting
-  - cargo build --manifest-path=codespan-reporting/Cargo.toml --verbose
-  - cargo test --manifest-path=codespan-reporting/Cargo.toml --verbose
+  - cargo build --manifest-path=codespan-reporting/Cargo.toml --verbose --no-default-features --features="$REPORTING_CARGO_FEATURES"
+  - cargo test --manifest-path=codespan-reporting/Cargo.toml --verbose --no-default-features --features="$REPORTING_CARGO_FEATURES"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,31 @@
 language: rust
 cache: cargo
+
 rust:
-  - stable
-  - beta
-  - nightly
+- stable
+- beta
+- nightly
+
+env:
+  - CARGO_FEATURES=""
+  - CARGO_FEATURES="memory_usage"
+  - CARGO_FEATURES="serialization"
+
 matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
+
+script:
+  # We manually build/test each crate and pass in any necessary feature flags
+  # to work around rust-lang/cargo#4942
+  
+  # codespan
+  - cargo build -manifest-path=codespan/Cargo.toml --verbose --no-default-features --features="$CARGO_FEATURES"
+  - cargo test -manifest-path=codespan/Cargo.toml --verbose --no-default-features --features="$CARGO_FEATURES"
+  # codespan-lsp
+  - cargo build -manifest-path=codespan-lsp/Cargo.toml --verbose
+  - cargo test -manifest-path=codespan-lsp/Cargo.toml --verbose
+  # codespan-reporting
+  - cargo build -manifest-path=codespan-reporting/Cargo.toml --verbose
+  - cargo test -manifest-path=codespan-reporting/Cargo.toml --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,16 @@ matrix:
   fast_finish: true
 
 script:
+  - set -ex
   # We manually build/test each crate and pass in any necessary feature flags
   # to work around rust-lang/cargo#4942
   
   # codespan
-  - cargo build -manifest-path=codespan/Cargo.toml --verbose --no-default-features --features="$CARGO_FEATURES"
-  - cargo test -manifest-path=codespan/Cargo.toml --verbose --no-default-features --features="$CARGO_FEATURES"
+  - cargo build --manifest-path=codespan/Cargo.toml --verbose --no-default-features --features="$CARGO_FEATURES"
+  - cargo test --manifest-path=codespan/Cargo.toml --verbose --no-default-features --features="$CARGO_FEATURES"
   # codespan-lsp
-  - cargo build -manifest-path=codespan-lsp/Cargo.toml --verbose
-  - cargo test -manifest-path=codespan-lsp/Cargo.toml --verbose
+  - cargo build --manifest-path=codespan-lsp/Cargo.toml --verbose
+  - cargo test --manifest-path=codespan-lsp/Cargo.toml --verbose
   # codespan-reporting
-  - cargo build -manifest-path=codespan-reporting/Cargo.toml --verbose
-  - cargo test -manifest-path=codespan-reporting/Cargo.toml --verbose
+  - cargo build --manifest-path=codespan-reporting/Cargo.toml --verbose
+  - cargo test --manifest-path=codespan-reporting/Cargo.toml --verbose

--- a/codespan-reporting/Cargo.toml
+++ b/codespan-reporting/Cargo.toml
@@ -13,6 +13,11 @@ exclude = ["assets/**"]
 [dependencies]
 codespan = { path = "../codespan", version = "0.1.1" }
 termcolor = "0.3.4"
+heapsize = { version = "0.4", optional = true }
+heapsize_derive = { version = "0.1", optional = true }
 
 [dev-dependencies]
 structopt = "0.2.7"
+
+[features]
+memory_usage = ["heapsize_derive", "heapsize", "codespan/memory_usage"]

--- a/codespan-reporting/src/diagnostic.rs
+++ b/codespan-reporting/src/diagnostic.rs
@@ -6,6 +6,7 @@ use Severity;
 
 /// A style for the label
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 pub enum LabelStyle {
     /// The main focus of the diagnostic
     Primary,
@@ -15,6 +16,7 @@ pub enum LabelStyle {
 
 /// A label describing an underlined region of code associated with a diagnostic
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 pub struct Label {
     /// The span we are going to include in the final snippet.
     pub span: ByteSpan,
@@ -49,6 +51,7 @@ impl Label {
 
 /// Represents a diagnostic message and associated child messages.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 pub struct Diagnostic {
     /// The overall severity of the diagnostic
     pub severity: Severity,

--- a/codespan-reporting/src/lib.rs
+++ b/codespan-reporting/src/lib.rs
@@ -5,6 +5,11 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::str::FromStr;
 use termcolor::{Color, ColorChoice};
+#[cfg(feature = "memory_usage")]
+extern crate heapsize;
+#[cfg(feature = "memory_usage")]
+#[macro_use]
+extern crate heapsize_derive;
 
 mod diagnostic;
 mod emitter;
@@ -25,6 +30,7 @@ pub use self::emitter::emit;
 /// assert!(Severity::Note > Severity::Help);
 /// ```
 #[derive(Copy, Clone, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 pub enum Severity {
     /// An unexpected bug.
     Bug,

--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -14,10 +14,12 @@ failure = "0.1.1"
 serde_derive = { version = "1", optional = true }
 serde = { version = "1", optional = true }
 itertools = "0.7"
+heapsize = { version = "0.4", optional = true }
+heapsize_derive = { version = "0.1", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "0.5.0"
 
-
 [features]
 serialization = ["serde", "serde/rc", "serde_derive"]
+memory_usage = ["heapsize_derive", "heapsize"]

--- a/codespan/src/codemap.rs
+++ b/codespan/src/codemap.rs
@@ -9,6 +9,7 @@ use index::{ByteIndex, ByteOffset, RawIndex};
 
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 pub struct CodeMap {
     files: Vec<Arc<FileMap>>,
 }

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::{fmt, io};
 
+#[cfg(feature = "memory_usage")]
 use heapsize::{self, HeapSizeOf};
 use index::{ByteIndex, ByteOffset, ColumnIndex, LineIndex, LineOffset, RawIndex, RawOffset};
 use span::ByteSpan;
@@ -60,6 +61,7 @@ impl fmt::Display for FileName {
     }
 }
 
+#[cfg(feature = "memory_usage")]
 impl HeapSizeOf for FileName {
     fn heap_size_of_children(&self) -> usize {
         match *self {

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -9,6 +9,7 @@ use span::ByteSpan;
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 pub enum FileName {
     /// A real file on disk
     Real(PathBuf),
@@ -92,6 +93,7 @@ pub enum SpanError {
 
 #[derive(Debug)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 /// Some source code
 pub struct FileMap<S = String> {
     /// The name of the file that the source came from

--- a/codespan/src/index.rs
+++ b/codespan/src/index.rs
@@ -13,6 +13,7 @@ pub type RawOffset = i64;
 /// A zero-indexed line offset into a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 pub struct LineIndex(pub RawIndex);
 
 impl LineIndex {
@@ -51,6 +52,7 @@ impl fmt::Debug for LineIndex {
 /// A 1-indexed line number. Useful for pretty printing source locations.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 pub struct LineNumber(RawIndex);
 
 impl fmt::Debug for LineNumber {
@@ -70,6 +72,7 @@ impl fmt::Display for LineNumber {
 /// A line offset in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 pub struct LineOffset(pub RawOffset);
 
 impl Default for LineOffset {
@@ -95,6 +98,7 @@ impl fmt::Display for LineOffset {
 /// A zero-indexed column offset into a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 pub struct ColumnIndex(pub RawIndex);
 
 impl ColumnIndex {
@@ -133,6 +137,7 @@ impl fmt::Debug for ColumnIndex {
 /// A 1-indexed column number. Useful for pretty printing source locations.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 pub struct ColumnNumber(RawIndex);
 
 impl fmt::Debug for ColumnNumber {
@@ -152,6 +157,7 @@ impl fmt::Display for ColumnNumber {
 /// A column offset in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 pub struct ColumnOffset(pub RawOffset);
 
 impl Default for ColumnOffset {
@@ -177,6 +183,7 @@ impl fmt::Display for ColumnOffset {
 /// A byte position in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 pub struct ByteIndex(pub RawIndex);
 
 impl ByteIndex {
@@ -214,6 +221,7 @@ impl fmt::Display for ByteIndex {
 /// A byte offset in a source file
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 pub struct ByteOffset(pub RawOffset);
 
 impl ByteOffset {

--- a/codespan/src/lib.rs
+++ b/codespan/src/lib.rs
@@ -8,6 +8,8 @@
 //!
 //! - **serialization** - Adds `Serialize` and `Deserialize` implementations
 //!   for use with `serde`
+//! - **memory_usage** - Adds `HeapSizeOf` implementations for use with the
+//!   `heapsize` crate
 
 #[macro_use]
 extern crate failure;

--- a/codespan/src/lib.rs
+++ b/codespan/src/lib.rs
@@ -22,6 +22,12 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
+#[cfg(feature = "memory_usage")]
+extern crate heapsize;
+#[cfg(feature = "memory_usage")]
+#[macro_use]
+extern crate heapsize_derive;
+
 mod codemap;
 mod filemap;
 mod index;

--- a/codespan/src/span.rs
+++ b/codespan/src/span.rs
@@ -6,6 +6,7 @@ use index::{ByteIndex, Index};
 /// A region of code in a source file
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
 pub struct Span<I> {
     start: I,
     end: I,


### PR DESCRIPTION
I often like having the ability to track how much memory my compiler/parser is using. This PR implements `HeapSizeOf` from the [heapsize] crate for various data types in `codespan`, hidden behind an off-by-default feature flag.

[heapsize]: https://crates.io/crates/heapsize