### PR TITLE
Add serde support to codespan-reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   - CARGO_FEATURES="memory_usage" 
     REPORTING_CARGO_FEATURES="memory_usage"
   - CARGO_FEATURES="serialization"
-    REPORTING_CARGO_FEATURES=""
+    REPORTING_CARGO_FEATURES="serialization"
 
 matrix:
   allow_failures:

--- a/codespan-reporting/Cargo.toml
+++ b/codespan-reporting/Cargo.toml
@@ -15,9 +15,12 @@ codespan = { path = "../codespan", version = "0.1.3" }
 termcolor = "0.3.4"
 heapsize = { version = "0.4", optional = true }
 heapsize_derive = { version = "0.1", optional = true }
+serde_derive = { version = "1", optional = true }
+serde = { version = "1", optional = true }
 
 [dev-dependencies]
 structopt = "0.2.7"
 
 [features]
+serialization = ["serde", "serde/rc", "serde_derive", "codespan/serialization"]
 memory_usage = ["heapsize_derive", "heapsize", "codespan/memory_usage"]

--- a/codespan-reporting/src/diagnostic.rs
+++ b/codespan-reporting/src/diagnostic.rs
@@ -7,6 +7,7 @@ use Severity;
 /// A style for the label
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub enum LabelStyle {
     /// The main focus of the diagnostic
     Primary,
@@ -17,6 +18,7 @@ pub enum LabelStyle {
 /// A label describing an underlined region of code associated with a diagnostic
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct Label {
     /// The span we are going to include in the final snippet.
     pub span: ByteSpan,
@@ -52,6 +54,7 @@ impl Label {
 /// Represents a diagnostic message and associated child messages.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct Diagnostic {
     /// The overall severity of the diagnostic
     pub severity: Severity,

--- a/codespan-reporting/src/lib.rs
+++ b/codespan-reporting/src/lib.rs
@@ -5,11 +5,18 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::str::FromStr;
 use termcolor::{Color, ColorChoice};
+
 #[cfg(feature = "memory_usage")]
 extern crate heapsize;
 #[cfg(feature = "memory_usage")]
 #[macro_use]
 extern crate heapsize_derive;
+
+#[cfg(feature = "serialization")]
+extern crate serde;
+#[cfg(feature = "serialization")]
+#[macro_use]
+extern crate serde_derive;
 
 mod diagnostic;
 mod emitter;
@@ -31,6 +38,7 @@ pub use self::emitter::emit;
 /// ```
 #[derive(Copy, Clone, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub enum Severity {
     /// An unexpected bug.
     Bug,


### PR DESCRIPTION
I just started putting together a "compile-test" crate for my toy C compiler and realised `Diagnostic` isn't serializable. This PR adds `#[derive(Serialize, Deserialize)]` to the various types in `codespan-reporting`.