### PR TITLE
Let users iterate over the FileMaps in a CodeMap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 cache: cargo
 
 rust:
+  - 1.26 # Required for `impl Trait`
   - stable
   - beta
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 cache: cargo
 
 rust:
-  - 1.26 # Required for `impl Trait`
+  - 1.26.2 # Required for `impl Trait`
   - stable
   - beta
   - nightly

--- a/codespan/src/codemap.rs
+++ b/codespan/src/codemap.rs
@@ -97,6 +97,10 @@ impl CodeMap {
         })
     }
 
+    pub fn iter(&self) -> impl Iterator<Item=&Arc<FileMap>> {
+        self.files.iter()
+    }
+
     fn find_index(&self, index: ByteIndex) -> Option<usize> {
         use std::cmp::Ordering;
 


### PR DESCRIPTION
I'm not sure whether you'd prefer to return `&[Arc<FileMap>]` or `impl Iterator<Item=&Arc<FileMap>>` here. My reasoning is that you may want to change the underlying implementation one day (e.g. use a `HashMap` or binary search tree for faster lookup), but `impl Trait` may affect the minimum version of `rustc`.