### PR TITLE
Implement more things for FileName

### DIFF
--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -61,6 +61,27 @@ impl From<&'static str> for FileName {
     }
 }
 
+impl AsRef<Path> for FileName {
+    fn as_ref(&self) -> &Path {
+        match *self {
+            FileName::Real(ref path) => path.as_ref(),
+            FileName::Virtual(ref cow) => Path::new(cow.as_ref()),
+        }
+    }
+}
+
+impl PartialEq<Path> for FileName {
+    fn eq(&self, other: &Path) -> bool {
+        self.as_ref() == other
+    }
+}
+
+impl PartialEq<PathBuf> for FileName {
+    fn eq(&self, other: &PathBuf) -> bool {
+        self.as_ref() == other.as_path()
+    }
+}
+
 impl FileName {
     pub fn real<T: Into<PathBuf>>(name: T) -> FileName {
         FileName::Real(name.into())

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -24,6 +24,25 @@ impl From<PathBuf> for FileName {
     }
 }
 
+impl From<FileName> for PathBuf {
+    fn from(name: FileName) -> PathBuf {
+        match name {
+            FileName::Real(path) => path,
+            FileName::Virtual(Cow::Owned(owned)) => PathBuf::from(owned),
+            FileName::Virtual(Cow::Borrowed(borrowed)) => PathBuf::from(borrowed),
+        }
+    }
+}
+
+impl<'a> From<&'a FileName> for &'a Path {
+    fn from(name: &'a FileName) -> &'a Path {
+        match *name {
+            FileName::Real(ref path) => path,
+            FileName::Virtual(ref cow) => Path::new(cow.as_ref()),
+        }
+    }
+}
+
 impl<'a> From<&'a Path> for FileName {
     fn from(name: &Path) -> FileName {
         FileName::real(name)

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -9,7 +9,7 @@ use heapsize::{self, HeapSizeOf};
 use index::{ByteIndex, ByteOffset, ColumnIndex, LineIndex, LineOffset, RawIndex, RawOffset};
 use span::ByteSpan;
 
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub enum FileName {
     /// A real file on disk


### PR DESCRIPTION
This adds a couple relatively small changes to make interoperating between `FileName` and `Path`/`PathBuf` a bit easier:

- Derive `Hash` so `FileName` can be used as the key in things like `HashMap`
- `From<FileName>` for `Path` and `PathBuf` (only requires an allocation in the `Cow::Borrowed` case)
- `AsRef<Path>` (useful for things like `File::open(...)`)
-  `PartialEq<PathBuf>`/`PartialEq<Path>` for comparing a `FileName` to `Path` and `PathBuf`