### PR TITLE
Make CodeMap generic over AsRef<str>

### DIFF
--- a/codespan-reporting/src/emitter.rs
+++ b/codespan-reporting/src/emitter.rs
@@ -15,9 +15,10 @@ impl<T: fmt::Display> fmt::Display for Pad<T> {
     }
 }
 
-pub fn emit<W>(mut writer: W, codemap: &CodeMap, diagnostic: &Diagnostic) -> io::Result<()>
+pub fn emit<W, S>(mut writer: W, codemap: &CodeMap<S>, diagnostic: &Diagnostic) -> io::Result<()>
 where
     W: WriteColor,
+    S: AsRef<str>,
 {
     let supports_color = writer.supports_color();
     let line_location_color = ColorSpec::new()

--- a/codespan/src/codemap.rs
+++ b/codespan/src/codemap.rs
@@ -10,16 +10,22 @@ use index::{ByteIndex, ByteOffset, RawIndex};
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "memory_usage", derive(HeapSizeOf))]
-pub struct CodeMap<S: AsRef<str> = String> {
+pub struct CodeMap<S = String> {
     files: Vec<Arc<FileMap<S>>>,
 }
 
-impl<S: AsRef<str>> CodeMap<S> {
+impl<S> CodeMap<S> {
     /// Creates an empty `CodeMap`.
     pub fn new() -> CodeMap<S> {
         CodeMap::default()
     }
 
+    pub fn iter(&self) -> impl Iterator<Item = &Arc<FileMap<S>>> {
+        self.files.iter()
+    }
+}
+
+impl<S: AsRef<str>> CodeMap<S> {
     /// The next start index to use for a new filemap
     fn next_start_index(&self) -> ByteIndex {
         let end_index = self
@@ -38,6 +44,7 @@ impl<S: AsRef<str>> CodeMap<S> {
         self.files.push(file.clone());
         file
     }
+
     /// Looks up the `File` that contains the specified byte index.
     pub fn find_file(&self, index: ByteIndex) -> Option<&Arc<FileMap<S>>> {
         self.find_index(index).map(|i| &self.files[i])
@@ -89,13 +96,8 @@ impl<S: AsRef<str>> CodeMap<S> {
                     },
                     None => self.add_filemap(file.name().clone(), src),
                 }
-
             }
         })
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &Arc<FileMap<S>>> {
-        self.files.iter()
     }
 
     fn find_index(&self, index: ByteIndex) -> Option<usize> {
@@ -120,13 +122,14 @@ impl<S: AsRef<str> + From<String>> CodeMap<S> {
     }
 }
 
-impl<S: AsRef<str>> Default for CodeMap<S> {
+impl<S> Default for CodeMap<S> {
     fn default() -> Self {
         CodeMap {
             files: vec![],
         }
     }
 }
+
 
 #[cfg(test)]
 mod tests {

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -175,9 +175,9 @@ pub struct FileMap<S = String> {
     lines: Vec<ByteOffset>,
 }
 
-impl FileMap {
+impl<S: AsRef<str> + From<String>> FileMap<S> {
     /// Read some source code from a file, loading it into a filemap
-    pub(crate) fn from_disk<P: Into<PathBuf>>(name: P, start: ByteIndex) -> io::Result<FileMap> {
+    pub(crate) fn from_disk<P: Into<PathBuf>>(name: P, start: ByteIndex) -> io::Result<FileMap<S>> {
         use std::fs::File;
         use std::io::Read;
 
@@ -186,7 +186,7 @@ impl FileMap {
         let mut src = String::new();
         file.read_to_string(&mut src)?;
 
-        Ok(FileMap::with_index(FileName::Real(name), src, start))
+        Ok(FileMap::with_index(FileName::Real(name), src.into(), start))
     }
 }
 


### PR DESCRIPTION
This should be a backwards-compatible change, as everything still defaults to `String` if no generic argument is given. It *does* allow using `&str` instead of `String` for file contents though.