### PR TITLE
Add `emit_single`, which emits a Diagnostic given a single FileMap

### DIFF
--- a/codespan-reporting/src/lib.rs
+++ b/codespan-reporting/src/lib.rs
@@ -22,7 +22,7 @@ mod diagnostic;
 mod emitter;
 
 pub use self::diagnostic::{Diagnostic, Label, LabelStyle};
-pub use self::emitter::emit;
+pub use self::emitter::{emit, emit_single};
 
 /// A severity level for diagnostic messages
 ///


### PR DESCRIPTION
My program performs a sort-of recursive-descend approach to files. As such I don't have all files loaded at the same time. Thus, it's hard for me to use a `CodeMap`. Instead, I'd like to be able to emit diagnostics just given a single `FileMap`.

This PR adds a `emit_single` function, which can be used to emit diagnostics given a `FileMap` instead of a `CodeMap`.