### PR TITLE
Add Arret to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Codespan is used in the following projects:
 - [Gluon](https://github.com/gluon-lang/gluon)
 - [Pikelet](https://github.com/pikelet-lang/pikelet)
 - [Gleam](https://github.com/lpil/gleam/)
+- [Arret](https://arret-lang.org)
 
 ## Acknowledgments
 


### PR DESCRIPTION
Since etaoins/arret@7cd236e it uses `codespan` and `codespan-reporting` for all of its source locations and diagnostics.