### PR TITLE
Make diagnostics look more like what the LSP expects

### DIFF
--- a/codespan-reporting/examples/emit.rs
+++ b/codespan-reporting/examples/emit.rs
@@ -2,7 +2,7 @@ use structopt::StructOpt;
 
 use codespan::{CodeMap, Span};
 use codespan_reporting::termcolor::StandardStream;
-use codespan_reporting::{emit, ColorArg, Diagnostic, Label, Severity};
+use codespan_reporting::{emit, ColorArg, Diagnostic, Label};
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "emit")]
@@ -31,25 +31,23 @@ fn main() {
     let file_map = code_map.add_filemap("test".into(), source.to_string());
 
     let str_start = file_map.byte_index(3.into(), 6.into()).unwrap();
-    let error = Diagnostic::new(Severity::Error, "Unexpected type in `+` application")
-        .with_label(
-            Label::new_primary(Span::from_offset(str_start, 2.into()))
-                .with_message("Expected integer but got string"),
-        )
-        .with_label(
-            Label::new_secondary(Span::from_offset(str_start, 2.into()))
-                .with_message("Expected integer but got string"),
-        )
-        .with_code("E0001");
+    let error = Diagnostic::new_error(
+        "Unexpected type in `+` application",
+        Label::new(
+            Span::from_offset(str_start, 2.into()),
+            "Expected integer but got string",
+        ),
+    )
+    .with_code("E0001")
+    .with_secondary_labels(vec![Label::new(
+        Span::from_offset(str_start, 2.into()),
+        "Expected integer but got string",
+    )]);
 
     let line_start = file_map.byte_index(2.into(), 3.into()).unwrap();
-    let warning = Diagnostic::new(
-        Severity::Warning,
+    let warning = Diagnostic::new_warning(
         "`+` function has no effect unless its result is used",
-    )
-    .with_label(
-        Label::new_primary(Span::from_offset(line_start, 27.into()))
-            .with_message("Value discarded"),
+        Label::new(Span::from_offset(line_start, 27.into()), "Value discarded"),
     );
 
     let diagnostics = [error, warning];

--- a/codespan-reporting/src/diagnostic.rs
+++ b/codespan-reporting/src/diagnostic.rs
@@ -18,10 +18,10 @@ pub struct Label {
 }
 
 impl Label {
-    pub fn new(span: ByteSpan, mesaage: impl Into<String>) -> Label {
+    pub fn new(span: ByteSpan, message: impl Into<String>) -> Label {
         Label {
             span,
-            message: mesaage.into(),
+            message: message.into(),
         }
     }
 }

--- a/codespan-reporting/src/diagnostic.rs
+++ b/codespan-reporting/src/diagnostic.rs
@@ -26,7 +26,8 @@ impl Label {
     }
 }
 
-/// Represents a diagnostic message and associated child messages.
+/// Represents a diagnostic message that can provide information like errors and
+/// warnings to the user.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "memory_usage", derive(heapsize_derive::HeapSizeOf))]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
@@ -37,7 +38,7 @@ pub struct Diagnostic {
     pub code: Option<String>,
     /// The main message associated with this diagnostic.
     pub message: String,
-    /// A label that marks the primary cause of this diagnostic.
+    /// A label that describes the primary cause of this diagnostic.
     pub primary_label: Label,
     /// Secondary labels that provide additional context for the diagnostic.
     pub secondary_labels: Vec<Label>,

--- a/codespan-reporting/src/diagnostic.rs
+++ b/codespan-reporting/src/diagnostic.rs
@@ -6,18 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Severity;
 
-/// A style for the label
-#[derive(Copy, Clone, PartialEq, Debug)]
-#[cfg_attr(feature = "memory_usage", derive(heapsize_derive::HeapSizeOf))]
-#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
-pub enum LabelStyle {
-    /// The main focus of the diagnostic
-    Primary,
-    /// Supporting labels that may help to isolate the cause of the diagnostic
-    Secondary,
-}
-
-/// A label describing an underlined region of code associated with a diagnostic
+/// A label describing an underlined region of code associated with a diagnostic.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "memory_usage", derive(heapsize_derive::HeapSizeOf))]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
@@ -26,30 +15,14 @@ pub struct Label {
     pub span: ByteSpan,
     /// A message to provide some additional information for the underlined code.
     pub message: String,
-    /// The style to use for the label.
-    pub style: LabelStyle,
 }
 
 impl Label {
-    pub fn new(span: ByteSpan, style: LabelStyle) -> Label {
+    pub fn new(span: ByteSpan, mesaage: impl Into<String>) -> Label {
         Label {
             span,
-            message: String::new(),
-            style,
+            message: mesaage.into(),
         }
-    }
-
-    pub fn new_primary(span: ByteSpan) -> Label {
-        Label::new(span, LabelStyle::Primary)
-    }
-
-    pub fn new_secondary(span: ByteSpan) -> Label {
-        Label::new(span, LabelStyle::Secondary)
-    }
-
-    pub fn with_message(mut self, message: impl Into<String>) -> Label {
-        self.message = message.into();
-        self
     }
 }
 
@@ -62,41 +35,43 @@ pub struct Diagnostic {
     pub severity: Severity,
     /// An optional code that identifies this diagnostic.
     pub code: Option<String>,
-    /// The main message associated with this diagnostic
+    /// The main message associated with this diagnostic.
     pub message: String,
-    /// The labelled spans marking the regions of code that cause this
-    /// diagnostic to be raised
-    pub labels: Vec<Label>,
+    /// A label that marks the primary cause of this diagnostic.
+    pub primary_label: Label,
+    /// Secondary labels that provide additional context for the diagnostic.
+    pub secondary_labels: Vec<Label>,
 }
 
 impl Diagnostic {
-    pub fn new(severity: Severity, message: impl Into<String>) -> Diagnostic {
+    pub fn new(severity: Severity, message: impl Into<String>, primary_label: Label) -> Diagnostic {
         Diagnostic {
             severity,
             code: None,
             message: message.into(),
-            labels: Vec::new(),
+            primary_label,
+            secondary_labels: Vec::new(),
         }
     }
 
-    pub fn new_bug(message: impl Into<String>) -> Diagnostic {
-        Diagnostic::new(Severity::Bug, message)
+    pub fn new_bug(message: impl Into<String>, primary_label: Label) -> Diagnostic {
+        Diagnostic::new(Severity::Bug, message, primary_label)
     }
 
-    pub fn new_error(message: impl Into<String>) -> Diagnostic {
-        Diagnostic::new(Severity::Error, message)
+    pub fn new_error(message: impl Into<String>, primary_label: Label) -> Diagnostic {
+        Diagnostic::new(Severity::Error, message, primary_label)
     }
 
-    pub fn new_warning(message: impl Into<String>) -> Diagnostic {
-        Diagnostic::new(Severity::Warning, message)
+    pub fn new_warning(message: impl Into<String>, primary_label: Label) -> Diagnostic {
+        Diagnostic::new(Severity::Warning, message, primary_label)
     }
 
-    pub fn new_note(message: impl Into<String>) -> Diagnostic {
-        Diagnostic::new(Severity::Note, message)
+    pub fn new_note(message: impl Into<String>, primary_label: Label) -> Diagnostic {
+        Diagnostic::new(Severity::Note, message, primary_label)
     }
 
-    pub fn new_help(message: impl Into<String>) -> Diagnostic {
-        Diagnostic::new(Severity::Help, message)
+    pub fn new_help(message: impl Into<String>, primary_label: Label) -> Diagnostic {
+        Diagnostic::new(Severity::Help, message, primary_label)
     }
 
     pub fn with_code(mut self, code: impl Into<String>) -> Diagnostic {
@@ -104,13 +79,8 @@ impl Diagnostic {
         self
     }
 
-    pub fn with_label(mut self, label: Label) -> Diagnostic {
-        self.labels.push(label);
-        self
-    }
-
-    pub fn with_labels(mut self, labels: impl IntoIterator<Item = Label>) -> Diagnostic {
-        self.labels.extend(labels);
+    pub fn with_secondary_labels(mut self, labels: impl IntoIterator<Item = Label>) -> Diagnostic {
+        self.secondary_labels.extend(labels);
         self
     }
 }

--- a/codespan-reporting/src/emitter.rs
+++ b/codespan-reporting/src/emitter.rs
@@ -4,16 +4,28 @@ use termcolor::{Color, ColorSpec, WriteColor};
 
 use crate::{Diagnostic, Label, Severity};
 
+/// Configures how a diagnostic is rendered.
 #[derive(Clone, Debug)]
 pub struct Config {
+    /// The color to use when rendering bugs. Defaults to `Color::Red`.
     pub bug_color: Color,
+    /// The color to use when rendering errors. Defaults to `Color::Red`.
     pub error_color: Color,
+    /// The color to use when rendering warnings. Defaults to `Color::Yellow`.
     pub warning_color: Color,
+    /// The color to use when rendering notes. Defaults to `Color::Green`.
     pub note_color: Color,
+    /// The color to use when rendering helps. Defaults to `Color::Cyan`.
     pub help_color: Color,
+    /// The color to use when rendering secondary labels. Defaults to
+    /// `Color::Blue` (or `Color::Cyan` on windows).
     pub secondary_color: Color,
+    /// The color to use when rendering gutters. Defaults to `Color::Blue`
+    /// (or `Color::Cyan` on windows).
     pub gutter_color: Color,
+    /// The character to use when underlining a primary label. Defaults to: `^`.
     pub primary_mark: char,
+    /// The character to use when underlining a secondary label. Defaults to: `-`.
     pub secondary_mark: char,
 }
 

--- a/codespan-reporting/src/emitter.rs
+++ b/codespan-reporting/src/emitter.rs
@@ -231,8 +231,9 @@ impl<'a, S: AsRef<str>> MarkedSource<'a, S> {
 
     fn emit(&self, writer: &mut impl WriteColor, config: &Config) -> io::Result<()> {
         let gutter_spec = ColorSpec::new().set_fg(Some(config.gutter_color)).clone();
-        let label_color = self.label_color(config);
-        let label_spec = ColorSpec::new().set_fg(Some(label_color)).clone();
+        let label_spec = ColorSpec::new()
+            .set_fg(Some(self.label_color(config)))
+            .clone();
 
         let (start_line, start_column) = self.file.location(self.start()).expect("location_start");
         let (end_line, _) = self.file.location(self.end()).expect("location_end");

--- a/codespan-reporting/src/emitter.rs
+++ b/codespan-reporting/src/emitter.rs
@@ -1,8 +1,8 @@
-use codespan::{CodeMap, LineIndex, RawIndex};
+use codespan::{ByteSpan, CodeMap, FileMap, LineIndex, RawIndex};
 use std::io;
 use termcolor::{Color, ColorSpec, WriteColor};
 
-use crate::{Diagnostic, LabelStyle, Severity};
+use crate::{Diagnostic, Label, LabelStyle, Severity};
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -50,22 +50,6 @@ impl Config {
             Severity::Help => self.help_color,
         }
     }
-
-    /// The style used to mark the labelled section of code.
-    pub fn label_color(&self, severity: Severity, label_style: LabelStyle) -> Color {
-        match label_style {
-            LabelStyle::Primary => self.severity_color(severity),
-            LabelStyle::Secondary => self.secondary_color,
-        }
-    }
-
-    /// The character used for the underlined section of code.
-    fn underline_char(&self, label_style: LabelStyle) -> char {
-        match label_style {
-            LabelStyle::Primary => self.primary_mark,
-            LabelStyle::Secondary => self.secondary_mark,
-        }
-    }
 }
 
 pub fn emit(
@@ -78,186 +62,30 @@ pub fn emit(
 
     for label in &diagnostic.labels {
         match codemap.find_file(label.span.start()) {
-            None => {
-                if !label.message.is_empty() {
-                    write!(writer, "- {}", label.message)?;
-                    write!(writer, "\n")?;
-                }
-            },
+            None => SimpleMessage::new(&label.message).emit(&mut writer, config)?,
             Some(file) => {
-                let gutter_spec = ColorSpec::new().set_fg(Some(config.gutter_color)).clone();
-                let (start_line, start_column) =
-                    file.location(label.span.start()).expect("location_start");
-                let (end_line, _) = file.location(label.span.end()).expect("location_end");
-                let start_line_span = file.line_span(start_line).expect("line_span");
-                let end_line_span = file.line_span(end_line).expect("line_span");
-
-                // Use the length of the last line number as the gutter padding
-                let gutter_padding = format!("{}", end_line.number()).len();
-
-                // File name
-                //
-                // ```
-                // ┌╴ <test>:2:9
-                // ```
-
-                // Write gutter
-                writer.set_color(&gutter_spec)?;
-                write!(writer, "{: >width$} ┌╴ ", "", width = gutter_padding)?;
-                writer.reset()?;
-
-                // Write file name
-                write!(
-                    writer,
-                    "{file}:{line}:{column}",
-                    file = file.name(),
-                    line = start_line.number(),
-                    column = start_column.number(),
-                )?;
-                write!(writer, "\n")?;
-
-                // Source code snippet
-                //
-                // ```
-                //   │
-                // 2 │ (+ test "")
-                //   │         ^^ Expected integer but got string
-                //   ╵
-                // ```
-
-                // Write line number and gutter
-                writer.set_color(&gutter_spec)?;
-                write!(writer, "{: >width$} │ ", "", width = gutter_padding)?;
-                write!(writer, "\n")?;
-                write!(
-                    writer,
-                    "{: >width$} │ ",
-                    start_line.number(),
-                    width = gutter_padding,
-                )?;
-                writer.reset()?;
-
-                // Write source prefix before marked section
-                let source_prefix = file
-                    .src_slice(start_line_span.with_end(label.span.start()))
-                    .expect("prefix");
-                write!(writer, "{}", source_prefix)?;
-
-                let label_color = config.label_color(diagnostic.severity, label.style);
-                let label_spec = ColorSpec::new().set_fg(Some(label_color)).clone();
-
-                // Write marked section
-                let mark_len = if start_line == end_line {
-                    // Single line
-
-                    // Write marked source section
-                    let marked_source = file.src_slice(label.span).expect("marked_source");
-                    writer.set_color(&label_spec)?;
-                    write!(writer, "{}", marked_source)?;
-                    writer.reset()?;
-                    marked_source.len()
-                } else {
-                    // Multiple lines
-
-                    // Write marked source section
-                    let marked_source = file
-                        .src_slice(start_line_span.with_start(label.span.start()))
-                        .expect("start_of_marked");
-                    writer.set_color(&label_spec)?;
-                    write!(writer, "{}", marked_source)?;
-
-                    for line_index in ((start_line.to_usize() + 1)..end_line.to_usize())
-                        .map(|i| LineIndex::from(i as RawIndex))
-                    {
-                        // Write line number and gutter
-                        writer.set_color(&gutter_spec)?;
-                        write!(
-                            writer,
-                            "{: >width$} │ ",
-                            line_index.number(),
-                            width = gutter_padding,
-                        )?;
-
-                        // Write marked source section
-                        let line_span = file.line_span(line_index).expect("marked_line_span");
-                        let marked_source = file
-                            .src_slice(line_span)
-                            .expect("marked_source")
-                            .trim_end_matches(|ch: char| ch == '\r' || ch == '\n');
-                        writer.set_color(&label_spec)?;
-                        write!(writer, "{}", marked_source)?;
-                        write!(writer, "\n")?;
-                    }
-
-                    // Write line number and gutter
-                    writer.set_color(&gutter_spec)?;
-                    write!(
-                        writer,
-                        "{: >width$} │ ",
-                        end_line.number(),
-                        width = gutter_padding,
-                    )?;
-
-                    // Write marked source section
-                    let marked_source = file
-                        .src_slice(end_line_span.with_end(label.span.end()))
-                        .expect("marked_source");
-                    writer.set_color(&label_spec)?;
-                    write!(writer, "{}", marked_source)?;
-                    writer.reset()?;
-                    marked_source.len()
-                };
-
-                // Write source suffix after marked section
-                let source = file
-                    .src_slice(end_line_span.with_start(label.span.end()))
-                    .expect("suffix")
-                    .trim_end_matches(|ch: char| ch == '\r' || ch == '\n');
-                write!(writer, "{}", source)?;
-                write!(writer, "\n")?;
-
-                // Write underline gutter
-                writer.set_color(&gutter_spec)?;
-                write!(writer, "{: >width$} │ ", "", width = gutter_padding)?;
-                writer.reset()?;
-
-                // Write underline and label
-                writer.set_color(&label_spec)?;
-                write!(writer, "{: >width$}", "", width = source_prefix.len())?;
-                for _ in 0..mark_len {
-                    write!(writer, "{}", config.underline_char(label.style))?;
-                }
-                if !label.message.is_empty() {
-                    write!(writer, " {}", label.message)?;
-                    write!(writer, "\n")?;
-                }
-                writer.reset()?;
-
-                // Write final gutter
-                writer.set_color(&gutter_spec)?;
-                write!(writer, "{: >width$} ╵", "", width = gutter_padding)?;
-                write!(writer, "\n")?;
-                writer.reset()?;
+                MarkedSource::new(file, &diagnostic, &label).emit(&mut writer, config)?
             },
         }
     }
+
     Ok(())
 }
 
 /// Diagnostic header
 ///
-/// ```
+/// ```text
 /// error[E0001]: Unexpected type in `+` application
 /// ```
 #[derive(Copy, Clone, Debug)]
-struct Header<'doc> {
+struct Header<'a> {
     severity: Severity,
-    code: Option<&'doc str>,
-    message: &'doc str,
+    code: Option<&'a str>,
+    message: &'a str,
 }
 
-impl<'doc> Header<'doc> {
-    fn new(diagnostic: &'doc Diagnostic) -> Header<'doc> {
+impl<'a> Header<'a> {
+    fn new(diagnostic: &'a Diagnostic) -> Header<'a> {
         Header {
             severity: diagnostic.severity,
             code: diagnostic.code.as_ref().map(String::as_str),
@@ -306,6 +134,243 @@ impl<'doc> Header<'doc> {
         // ```
         writer.set_color(&message_spec)?;
         write!(writer, ": {}", self.message)?;
+        write!(writer, "\n")?;
+        writer.reset()?;
+
+        Ok(())
+    }
+}
+
+/// A simple message
+///
+/// ```text
+/// - Expected integer but got string
+/// ```
+struct SimpleMessage<'a> {
+    message: &'a str,
+}
+
+impl<'a> SimpleMessage<'a> {
+    fn new(message: &'a str) -> SimpleMessage<'a> {
+        SimpleMessage { message }
+    }
+
+    fn emit(&self, writer: &mut impl WriteColor, _config: &Config) -> io::Result<()> {
+        if !self.message.is_empty() {
+            write!(writer, "- {}", self.message)?;
+            write!(writer, "\n")?;
+        }
+
+        Ok(())
+    }
+}
+
+/// A marked section of source code
+///
+/// ```text
+///   ┌╴ <test>:2:9
+///   │
+/// 2 │ (+ test "")
+///   │         ^^ Expected integer but got string
+///   ╵
+/// ```
+struct MarkedSource<'a, S: AsRef<str>> {
+    file: &'a FileMap<S>,
+    span: ByteSpan,
+    message: &'a str,
+    severity: Option<Severity>,
+}
+
+impl<'a, S: AsRef<str>> MarkedSource<'a, S> {
+    fn new(
+        file: &'a FileMap<S>,
+        diagnostic: &Diagnostic,
+        label: &'a Label,
+    ) -> MarkedSource<'a, S> {
+        MarkedSource {
+            file,
+            span: label.span,
+            message: &label.message,
+            severity: match label.style {
+                LabelStyle::Primary => Some(diagnostic.severity),
+                LabelStyle::Secondary => None,
+            },
+        }
+    }
+
+    fn label_color(&self, config: &Config) -> Color {
+        match self.severity {
+            None => config.secondary_color,
+            Some(severity) => config.severity_color(severity),
+        }
+    }
+
+    fn underline_char(&self, config: &Config) -> char {
+        match self.severity {
+            Some(_) => config.primary_mark,
+            None => config.secondary_mark,
+        }
+    }
+
+    fn emit(&self, writer: &mut impl WriteColor, config: &Config) -> io::Result<()> {
+        let gutter_spec = ColorSpec::new().set_fg(Some(config.gutter_color)).clone();
+        let label_color = self.label_color(config);
+        let label_spec = ColorSpec::new().set_fg(Some(label_color)).clone();
+
+        let (start_line, start_column) = self
+            .file
+            .location(self.span.start())
+            .expect("location_start");
+        let (end_line, _) = self.file.location(self.span.end()).expect("location_end");
+        let start_line_span = self.file.line_span(start_line).expect("line_span");
+        let end_line_span = self.file.line_span(end_line).expect("line_span");
+
+        // Use the length of the last line number as the gutter padding
+        let gutter_padding = format!("{}", end_line.number()).len();
+
+        // File name
+        //
+        // ```
+        // ┌╴ <test>:2:9
+        // ```
+
+        // Write gutter
+        writer.set_color(&gutter_spec)?;
+        write!(writer, "{: >width$} ┌╴ ", "", width = gutter_padding)?;
+        writer.reset()?;
+
+        // Write file name
+        write!(
+            writer,
+            "{file}:{line}:{column}",
+            file = self.file.name(),
+            line = start_line.number(),
+            column = start_column.number(),
+        )?;
+        write!(writer, "\n")?;
+
+        // Source code snippet
+        //
+        // ```
+        //   │
+        // 2 │ (+ test "")
+        //   │         ^^ Expected integer but got string
+        //   ╵
+        // ```
+
+        // Write line number and gutter
+        writer.set_color(&gutter_spec)?;
+        write!(writer, "{: >width$} │ ", "", width = gutter_padding)?;
+        write!(writer, "\n")?;
+        write!(
+            writer,
+            "{: >width$} │ ",
+            start_line.number(),
+            width = gutter_padding,
+        )?;
+        writer.reset()?;
+
+        // Write source prefix before marked section
+        let source_prefix = self
+            .file
+            .src_slice(start_line_span.with_end(self.span.start()))
+            .expect("prefix");
+        write!(writer, "{}", source_prefix)?;
+
+        // Write marked section
+        let mark_len = if start_line == end_line {
+            // Single line
+
+            // Write marked source section
+            let marked_source = self.file.src_slice(self.span).expect("marked_source");
+            writer.set_color(&label_spec)?;
+            write!(writer, "{}", marked_source)?;
+            writer.reset()?;
+            marked_source.len()
+        } else {
+            // Multiple lines
+
+            // Write marked source section
+            let marked_source = self
+                .file
+                .src_slice(start_line_span.with_start(self.span.start()))
+                .expect("start_of_marked");
+            writer.set_color(&label_spec)?;
+            write!(writer, "{}", marked_source)?;
+
+            for line_index in ((start_line.to_usize() + 1)..end_line.to_usize())
+                .map(|i| LineIndex::from(i as RawIndex))
+            {
+                // Write line number and gutter
+                writer.set_color(&gutter_spec)?;
+                write!(
+                    writer,
+                    "{: >width$} │ ",
+                    line_index.number(),
+                    width = gutter_padding,
+                )?;
+
+                // Write marked source section
+                let line_span = self.file.line_span(line_index).expect("marked_line_span");
+                let marked_source = self
+                    .file
+                    .src_slice(line_span)
+                    .expect("marked_source")
+                    .trim_end_matches(|ch: char| ch == '\r' || ch == '\n');
+                writer.set_color(&label_spec)?;
+                write!(writer, "{}", marked_source)?;
+                write!(writer, "\n")?;
+            }
+
+            // Write line number and gutter
+            writer.set_color(&gutter_spec)?;
+            write!(
+                writer,
+                "{: >width$} │ ",
+                end_line.number(),
+                width = gutter_padding,
+            )?;
+
+            // Write marked source section
+            let marked_source = self
+                .file
+                .src_slice(end_line_span.with_end(self.span.end()))
+                .expect("marked_source");
+            writer.set_color(&label_spec)?;
+            write!(writer, "{}", marked_source)?;
+            writer.reset()?;
+            marked_source.len()
+        };
+
+        // Write source suffix after marked section
+        let source = self
+            .file
+            .src_slice(end_line_span.with_start(self.span.end()))
+            .expect("suffix")
+            .trim_end_matches(|ch: char| ch == '\r' || ch == '\n');
+        write!(writer, "{}", source)?;
+        write!(writer, "\n")?;
+
+        // Write underline gutter
+        writer.set_color(&gutter_spec)?;
+        write!(writer, "{: >width$} │ ", "", width = gutter_padding)?;
+        writer.reset()?;
+
+        // Write underline and label
+        writer.set_color(&label_spec)?;
+        write!(writer, "{: >width$}", "", width = source_prefix.len())?;
+        for _ in 0..mark_len {
+            write!(writer, "{}", self.underline_char(config))?;
+        }
+        if !self.message.is_empty() {
+            write!(writer, " {}", self.message)?;
+            write!(writer, "\n")?;
+        }
+        writer.reset()?;
+
+        // Write final gutter
+        writer.set_color(&gutter_spec)?;
+        write!(writer, "{: >width$} ╵", "", width = gutter_padding)?;
         write!(writer, "\n")?;
         writer.reset()?;
 

--- a/codespan-reporting/src/lib.rs
+++ b/codespan-reporting/src/lib.rs
@@ -9,7 +9,7 @@ mod emitter;
 
 pub use termcolor;
 
-pub use self::diagnostic::{Diagnostic, Label, LabelStyle};
+pub use self::diagnostic::{Diagnostic, Label};
 pub use self::emitter::{emit, Config};
 
 /// A severity level for diagnostic messages


### PR DESCRIPTION
The new diagnostic structures look like this:

```rust
pub struct Label {
    /// The span we are going to include in the final snippet.
    pub span: ByteSpan,
    /// A message to provide some additional information for the underlined code.
    pub message: String,
}

pub struct Diagnostic {
    /// The overall severity of the diagnostic
    pub severity: Severity,
    /// An optional code that identifies this diagnostic.
    pub code: Option<String>,
    /// The main message associated with this diagnostic.
    pub message: String,
    /// A label that marks the primary cause of this diagnostic.
    pub primary_label: Label,
    /// Secondary labels that provide additional context for the diagnostic.
    pub secondary_labels: Vec<Label>,
}
```