### PR TITLE
Remove failure

### DIFF
--- a/codespan-lsp/Cargo.toml
+++ b/codespan-lsp/Cargo.toml
@@ -12,6 +12,5 @@ edition = "2018"
 [dependencies]
 codespan = { version = "0.3.0", path = "../codespan" } # CODESPAN
 codespan-reporting = { version = "0.3.0", path = "../codespan-reporting/" } # CODESPAN
-failure = "0.1"
 lsp-types = "0.57"
 url = "1"

--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -11,7 +11,6 @@ documentation = "https://docs.rs/codespan"
 edition = "2018"
 
 [dependencies]
-failure = "0.1"
 heapsize = { version = "0.4", optional = true }
 heapsize_derive = { version = "0.1", optional = true }
 itertools = "0.8"

--- a/codespan/src/filemap.rs
+++ b/codespan/src/filemap.rs
@@ -2,48 +2,99 @@
 
 #[cfg(feature = "serialization")]
 use serde::{Deserialize, Serialize};
-use std::io;
+use std::{error, fmt, io};
 
 use crate::index::{
     ByteIndex, ByteOffset, ColumnIndex, LineIndex, LineOffset, RawIndex, RawOffset,
 };
 use crate::span::ByteSpan;
 
-#[derive(Debug, failure::Fail, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum LineIndexError {
-    #[fail(display = "Line out of bounds - given: {:?}, max: {:?}", given, max)]
     OutOfBounds { given: LineIndex, max: LineIndex },
 }
 
-#[derive(Debug, failure::Fail, PartialEq)]
+impl error::Error for LineIndexError {}
+
+impl fmt::Display for LineIndexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LineIndexError::OutOfBounds { given, max } => {
+                write!(f, "Line out of bounds - given: {:?}, max: {:?}", given, max)
+            },
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
 pub enum ByteIndexError {
-    #[fail(
-        display = "Byte index out of bounds - given: {}, span: {}",
-        given, span
-    )]
     OutOfBounds { given: ByteIndex, span: ByteSpan },
-    #[fail(
-        display = "Byte index points within a character boundary - given: {}",
-        given
-    )]
     InvalidCharBoundary { given: ByteIndex },
 }
 
-#[derive(Debug, failure::Fail, PartialEq)]
+impl error::Error for ByteIndexError {}
+
+impl fmt::Display for ByteIndexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ByteIndexError::OutOfBounds { given, span } => write!(
+                f,
+                "Byte index out of bounds - given: {}, span: {}",
+                given, span,
+            ),
+            ByteIndexError::InvalidCharBoundary { given } => write!(
+                f,
+                "Byte index points within a character boundary - given: {}",
+                given,
+            ),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
 pub enum LocationError {
-    #[fail(display = "Line out of bounds - given: {:?}, max: {:?}", given, max)]
-    LineOutOfBounds { given: LineIndex, max: LineIndex },
-    #[fail(display = "Column out of bounds - given: {:?}, max: {:?}", given, max)]
+    LineOutOfBounds {
+        given: LineIndex,
+        max: LineIndex,
+    },
     ColumnOutOfBounds {
         given: ColumnIndex,
         max: ColumnIndex,
     },
 }
 
-#[derive(Debug, failure::Fail, PartialEq)]
+impl error::Error for LocationError {}
+
+impl fmt::Display for LocationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LocationError::LineOutOfBounds { given, max } => {
+                write!(f, "Line out of bounds - given: {:?}, max: {:?}", given, max)
+            },
+            LocationError::ColumnOutOfBounds { given, max } => write!(
+                f,
+                "Column out of bounds - given: {:?}, max: {:?}",
+                given, max,
+            ),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
 pub enum SpanError {
-    #[fail(display = "Span out of bounds - given: {}, span: {}", given, span)]
     OutOfBounds { given: ByteSpan, span: ByteSpan },
+}
+
+impl error::Error for SpanError {}
+
+impl fmt::Display for SpanError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SpanError::OutOfBounds { given, span } => {
+                write!(f, "Span out of bounds - given: {}, span: {}", given, span)
+            },
+        }
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Failure seems not to be the right thing to use for libraries, and it seems like `std::error::Error` is good enough for our purposes right now.