### PR TITLE
Use color specs in config and move into struct

### DIFF
--- a/codespan-reporting/src/emitter/mod.rs
+++ b/codespan-reporting/src/emitter/mod.rs
@@ -1,6 +1,6 @@
 use codespan::Files;
 use std::io;
-use termcolor::{Color, WriteColor};
+use termcolor::{Color, ColorSpec, WriteColor};
 
 use crate::{Diagnostic, Severity};
 
@@ -40,33 +40,8 @@ pub struct Config {
     /// Column width of tabs.
     /// Defaults to: `4`.
     pub tab_width: usize,
-    /// The color to use when rendering bugs.
-    /// Defaults to `Color::Red`.
-    pub bug_color: Color,
-    /// The color to use when rendering errors.
-    /// Defaults to `Color::Red`.
-    pub error_color: Color,
-    /// The color to use when rendering warnings.
-    /// Defaults to `Color::Yellow`.
-    pub warning_color: Color,
-    /// The color to use when rendering notes.
-    /// Defaults to `Color::Green`.
-    pub note_color: Color,
-    /// The color to use when rendering helps.
-    /// Defaults to `Color::Cyan`.
-    pub help_color: Color,
-    /// The color to use when rendering secondary labels.
-    /// Defaults `Color::Blue` (or `Color::Cyan` on windows).
-    pub secondary_color: Color,
-    /// The color to use when rendering the line numbers.
-    /// Defaults `Color::Blue` (or `Color::Cyan` on windows).
-    pub line_number_color: Color,
-    /// The color to use when rendering the source code borders.
-    /// Defaults `Color::Blue` (or `Color::Cyan` on windows).
-    pub border_color: Color,
-    /// The color to use when rendering the note bullets.
-    /// Defaults `Color::Blue` (or `Color::Cyan` on windows).
-    pub note_bullet_color: Color,
+    /// Styles to use when rendering the diagnostic.
+    pub styles: Styles,
     /// The character to use when marking the top-left corner of the source.
     /// Defaults to: `'┌'`.
     pub border_top_left_char: char,
@@ -89,24 +64,10 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Config {
-        // Blue is really difficult to see on the standard windows command line
-        #[cfg(windows)]
-        const BLUE: Color = Color::Cyan;
-        #[cfg(not(windows))]
-        const BLUE: Color = Color::Blue;
-
         Config {
             display_style: DisplayStyle::Rich,
             tab_width: 4,
-            bug_color: Color::Red,
-            error_color: Color::Red,
-            warning_color: Color::Yellow,
-            note_color: Color::Green,
-            help_color: Color::Cyan,
-            secondary_color: BLUE,
-            line_number_color: BLUE,
-            border_color: BLUE,
-            note_bullet_color: BLUE,
+            styles: Styles::default(),
             border_top_left_char: '┌',
             border_top_char: '─',
             border_left_char: '│',
@@ -118,17 +79,6 @@ impl Default for Config {
 }
 
 impl Config {
-    /// The color used to mark a given severity.
-    pub fn severity_color(&self, severity: Severity) -> Color {
-        match severity {
-            Severity::Bug => self.bug_color,
-            Severity::Error => self.error_color,
-            Severity::Warning => self.warning_color,
-            Severity::Note => self.note_color,
-            Severity::Help => self.help_color,
-        }
-    }
-
     /// Measure the width of a string, taking into account the tab width.
     pub fn width(&self, s: &str) -> usize {
         use unicode_width::UnicodeWidthChar;
@@ -144,6 +94,114 @@ impl Config {
     /// Get the amount of spaces we should use for printing tabs.
     pub fn tab_padding(&self) -> String {
         (0..self.tab_width).map(|_| ' ').collect()
+    }
+}
+
+/// Styles to use when rendering the diagnostic.
+#[derive(Clone, Debug)]
+pub struct Styles {
+    /// The style to use when rendering bug headers.
+    /// Defaults to `fg:red bold intense`.
+    pub header_bug: ColorSpec,
+    /// The style to use when rendering error headers.
+    /// Defaults to `fg:red bold intense`.
+    pub header_error: ColorSpec,
+    /// The style to use when rendering warning headers.
+    /// Defaults to `fg:yellow bold intense`.
+    pub header_warning: ColorSpec,
+    /// The style to use when rendering note headers.
+    /// Defaults to `fg:green bold intense`.
+    pub header_note: ColorSpec,
+    /// The style to use when rendering help headers.
+    /// Defaults to `fg:cyan bold intense`.
+    pub header_help: ColorSpec,
+    /// The style to use when the main diagnostic message.
+    /// Defaults to `bold intense`.
+    pub header_message: ColorSpec,
+
+    /// The style to use when rendering bug labels.
+    /// Defaults to `fg:red`.
+    pub primary_label_bug: ColorSpec,
+    /// The style to use when rendering error labels.
+    /// Defaults to `fg:red`.
+    pub primary_label_error: ColorSpec,
+    /// The style to use when rendering warning labels.
+    /// Defaults to `fg:yellow`.
+    pub primary_label_warning: ColorSpec,
+    /// The style to use when rendering note labels.
+    /// Defaults to `fg:green`.
+    pub primary_label_note: ColorSpec,
+    /// The style to use when rendering help labels.
+    /// Defaults to `fg:cyan`.
+    pub primary_label_help: ColorSpec,
+    /// The style to use when rendering secondary labels.
+    /// Defaults `fg:blue` (or `fg:cyan` on windows).
+    pub secondary_label: ColorSpec,
+
+    /// The style to use when rendering the line numbers.
+    /// Defaults `fg:blue` (or `fg:cyan` on windows).
+    pub line_number: ColorSpec,
+    /// The style to use when rendering the source code borders.
+    /// Defaults `fg:blue` (or `fg:cyan` on windows).
+    pub border: ColorSpec,
+    /// The style to use when rendering the note bullets.
+    /// Defaults `fg:blue` (or `fg:cyan` on windows).
+    pub note_bullet: ColorSpec,
+}
+
+impl Styles {
+    /// The style used to mark a header at a given severity.
+    pub fn header(&self, severity: Severity) -> &ColorSpec {
+        match severity {
+            Severity::Bug => &self.header_bug,
+            Severity::Error => &self.header_error,
+            Severity::Warning => &self.header_warning,
+            Severity::Note => &self.header_note,
+            Severity::Help => &self.header_help,
+        }
+    }
+
+    /// The style used to mark a primary label at a given severity.
+    pub fn primary_label(&self, severity: Severity) -> &ColorSpec {
+        match severity {
+            Severity::Bug => &self.primary_label_bug,
+            Severity::Error => &self.primary_label_error,
+            Severity::Warning => &self.primary_label_warning,
+            Severity::Note => &self.primary_label_note,
+            Severity::Help => &self.primary_label_help,
+        }
+    }
+}
+
+impl Default for Styles {
+    fn default() -> Styles {
+        // Blue is really difficult to see on the standard windows command line
+        #[cfg(windows)]
+        const BLUE: Color = Color::Cyan;
+        #[cfg(not(windows))]
+        const BLUE: Color = Color::Blue;
+
+        let header = ColorSpec::new().set_bold(true).set_intense(true).clone();
+
+        Styles {
+            header_bug: header.clone().set_fg(Some(Color::Red)).clone(),
+            header_error: header.clone().set_fg(Some(Color::Red)).clone(),
+            header_warning: header.clone().set_fg(Some(Color::Yellow)).clone(),
+            header_note: header.clone().set_fg(Some(Color::Green)).clone(),
+            header_help: header.clone().set_fg(Some(Color::Cyan)).clone(),
+            header_message: header.clone(),
+
+            primary_label_bug: ColorSpec::new().set_fg(Some(Color::Red)).clone(),
+            primary_label_error: ColorSpec::new().set_fg(Some(Color::Red)).clone(),
+            primary_label_warning: ColorSpec::new().set_fg(Some(Color::Yellow)).clone(),
+            primary_label_note: ColorSpec::new().set_fg(Some(Color::Green)).clone(),
+            primary_label_help: ColorSpec::new().set_fg(Some(Color::Cyan)).clone(),
+            secondary_label: ColorSpec::new().set_fg(Some(BLUE)).clone(),
+
+            line_number: ColorSpec::new().set_fg(Some(BLUE)).clone(),
+            border: ColorSpec::new().set_fg(Some(BLUE)).clone(),
+            note_bullet: ColorSpec::new().set_fg(Some(BLUE)).clone(),
+        }
     }
 }
 

--- a/codespan-reporting/src/emitter/views/gutter.rs
+++ b/codespan-reporting/src/emitter/views/gutter.rs
@@ -1,6 +1,6 @@
 use codespan::LineNumber;
 use std::io;
-use termcolor::{ColorSpec, WriteColor};
+use termcolor::WriteColor;
 
 use crate::emitter::Config;
 
@@ -30,11 +30,7 @@ impl Gutter {
                 )?;
             },
             Some(line_number) => {
-                let line_number_spec = ColorSpec::new()
-                    .set_fg(Some(config.line_number_color))
-                    .clone();
-
-                writer.set_color(&line_number_spec)?;
+                writer.set_color(&config.styles.line_number)?;
                 write!(
                     writer,
                     "{line: >width$}",

--- a/codespan-reporting/src/emitter/views/header.rs
+++ b/codespan-reporting/src/emitter/views/header.rs
@@ -1,5 +1,5 @@
 use std::io;
-use termcolor::{ColorSpec, WriteColor};
+use termcolor::WriteColor;
 
 use crate::emitter::Config;
 use crate::{Diagnostic, Severity};
@@ -38,19 +38,12 @@ impl<'a> Header<'a> {
     }
 
     pub fn emit(&self, writer: &mut impl WriteColor, config: &Config) -> io::Result<()> {
-        let message_spec = ColorSpec::new().set_bold(true).set_intense(true).clone();
-        let primary_spec = ColorSpec::new()
-            .set_bold(true)
-            .set_intense(true)
-            .set_fg(Some(config.severity_color(self.severity)))
-            .clone();
-
         // Write severity name
         //
         // ```text
         // error
         // ```
-        writer.set_color(&primary_spec)?;
+        writer.set_color(config.styles.header(self.severity))?;
         write!(writer, "{}", self.severity_name())?;
         if let Some(code) = &self.code {
             // Write error code
@@ -66,7 +59,7 @@ impl<'a> Header<'a> {
         // ```text
         // : unexpected type in `+` application
         // ```
-        writer.set_color(&message_spec)?;
+        writer.set_color(&config.styles.header_message)?;
         write!(writer, ": {}", self.message)?;
         writer.reset()?;
 

--- a/codespan-reporting/src/emitter/views/note.rs
+++ b/codespan-reporting/src/emitter/views/note.rs
@@ -1,5 +1,5 @@
 use std::io;
-use termcolor::{ColorSpec, WriteColor};
+use termcolor::WriteColor;
 
 use crate::emitter::Config;
 
@@ -53,11 +53,7 @@ impl Bullet {
     }
 
     fn emit(&self, writer: &mut impl WriteColor, config: &Config) -> io::Result<()> {
-        let note_bullet_spec = ColorSpec::new()
-            .set_fg(Some(config.note_bullet_color))
-            .clone();
-
-        writer.set_color(&note_bullet_spec)?;
+        writer.set_color(&config.styles.note_bullet)?;
         write!(writer, "{}", config.note_bullet_char)?;
         writer.reset()?;
 


### PR DESCRIPTION
This means we don’t need to construct the color specs inline, and also provides more opportunities for customisation.