### PR TITLE
Ensure that we always print an underline character

### DIFF
--- a/codespan-reporting/src/emitter/views/source_snippet.rs
+++ b/codespan-reporting/src/emitter/views/source_snippet.rs
@@ -223,9 +223,9 @@ impl<'a> SourceSnippet<'a> {
             space = "",
             width = config.width(&source_prefix),
         )?;
-        // We use `std::cmp::max` here to ensure that we print at least one
+        // We use `usize::max` here to ensure that we print at least one
         // underline character - even when we have a zero-length span.
-        for _ in 0..std::cmp::max(mark_len, 1) {
+        for _ in 0..usize::max(mark_len, 1) {
             write!(writer, "{}", self.underline_char(config))?;
         }
         if !self.label.message.is_empty() {

--- a/codespan-reporting/src/emitter/views/source_snippet.rs
+++ b/codespan-reporting/src/emitter/views/source_snippet.rs
@@ -223,7 +223,9 @@ impl<'a> SourceSnippet<'a> {
             space = "",
             width = config.width(&source_prefix),
         )?;
-        for _ in 0..mark_len {
+        // We use `std::cmp::max` here to ensure that we print at least one
+        // underline character - even when we have a zero-length span.
+        for _ in 0..std::cmp::max(mark_len, 1) {
             write!(writer, "{}", self.underline_char(config))?;
         }
         if !self.label.message.is_empty() {

--- a/codespan-reporting/tests/emit.rs
+++ b/codespan-reporting/tests/emit.rs
@@ -2,6 +2,40 @@ use codespan::Files;
 use codespan_reporting::termcolor::{Buffer, WriteColor};
 use codespan_reporting::{emit, Config, Diagnostic, DisplayStyle, Label};
 
+mod empty_spans {
+    use super::*;
+
+    fn emit_test(writer: &mut impl WriteColor, config: &Config) {
+        let mut files = Files::new();
+
+        let file_id = files.add("hello", "Hello world!\nBye world!");
+        let eof = files.source_span(file_id).end();
+
+        let diagnostics = vec![
+            Diagnostic::new_note("middle", Label::new(file_id, 6..6, "middle")),
+            Diagnostic::new_note("end of line", Label::new(file_id, 12..12, "end of line")),
+            Diagnostic::new_note("end of file", Label::new(file_id, eof..eof, "end of file")),
+        ];
+
+        for diagnostic in &diagnostics {
+            emit(writer, config, &files, &diagnostic).unwrap();
+        }
+    }
+
+    #[test]
+    fn rich_no_color() {
+        let config = Config {
+            display_style: DisplayStyle::Rich,
+            ..Config::default()
+        };
+
+        let mut buffer = Buffer::no_color();
+        emit_test(&mut buffer, &config);
+        let result = String::from_utf8_lossy(buffer.as_slice());
+        insta::assert_snapshot_matches!("rich_no_color", result);
+    }
+}
+
 mod multifile {
     use super::*;
 

--- a/codespan-reporting/tests/snapshots/empty_spans__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/empty_spans__rich_no_color.snap
@@ -1,0 +1,31 @@
+---
+created: "2019-06-13T09:59:02.388803Z"
+creator: insta@0.8.1
+source: codespan-reporting/tests/emit.rs
+expression: result
+---
+note: middle
+
+   ┌── hello:1:7 ───
+   │ 
+ 1 │ Hello world!
+   │       ^ middle
+   │ 
+
+note: end of line
+
+   ┌── hello:1:13 ───
+   │ 
+ 1 │ Hello world!
+   │             ^ end of line
+   │ 
+
+note: end of file
+
+   ┌── hello:2:11 ───
+   │ 
+ 2 │ Bye world!
+   │           ^ end of file
+   │ 
+
+


### PR DESCRIPTION
This comes up if we have a zero-length span. Previously we’d not print any underline characters:

```text
   ┌── hello:1:7 ───
   │
 1 │ Hello world!
   │        middle
   │
```

This is kind of confusing! Now we print at least one:

```text
   ┌── hello:1:7 ───
   │
 1 │ Hello world!
   │       ^ middle
   │
```