### PR TITLE
Don’t highlight source with color

### DIFF
--- a/codespan-reporting/src/term/views/diagnostic.rs
+++ b/codespan-reporting/src/term/views/diagnostic.rs
@@ -2,8 +2,8 @@ use codespan::{Files, Location};
 use std::io;
 use termcolor::WriteColor;
 
-use crate::term::Config;
 use crate::diagnostic::Diagnostic;
+use crate::term::Config;
 
 use super::{Header, Locus, NewLine, SourceSnippet};
 

--- a/codespan-reporting/src/term/views/header.rs
+++ b/codespan-reporting/src/term/views/header.rs
@@ -1,8 +1,8 @@
 use std::io;
 use termcolor::WriteColor;
 
-use crate::term::Config;
 use crate::diagnostic::{Diagnostic, Severity};
+use crate::term::Config;
 
 use super::NewLine;
 

--- a/codespan-reporting/src/term/views/source_snippet/mod.rs
+++ b/codespan-reporting/src/term/views/source_snippet/mod.rs
@@ -89,7 +89,6 @@ impl<'a> SourceSnippet<'a> {
         let end_line_span = self.line_span(end.line).expect("end_line_span");
         let is_multiline = start.line != end.line;
 
-        let label_style = self.mark_style.label_style(config);
         // Use the length of the last line number as the gutter padding
         let gutter_padding = format!("{}", end.line.number()).len();
         // Cache the tabs we'll be using to pad the source strings.
@@ -142,21 +141,14 @@ impl<'a> SourceSnippet<'a> {
             BorderLeft::new().emit(writer, config)?;
             write!(writer, " ")?;
 
-            // Write source prefix before marked section
             let prefix_span = start_line_span.with_end(self.span.start());
             let source_prefix = self.source_slice(prefix_span, &tab).expect("source_prefix");
-            write!(writer, "{}", source_prefix)?;
-
-            // Write marked source section
             let marked_source = self.source_slice(self.span, &tab).expect("marked_source");
-            writer.set_color(label_style)?;
-            write!(writer, "{}", marked_source)?;
-            writer.reset()?;
 
-            // Write source suffix after marked section
-            let suffix_span = end_line_span.with_start(self.span.end());
-            let source_suffix = self.source_slice(suffix_span, &tab).expect("source_suffix");
-            write!(writer, "{}", source_suffix.trim_end_matches(line_trimmer))?;
+            // Write source line
+            let line_span = start_line_span;
+            let line_source = self.source_slice(line_span, &tab).expect("line_source");
+            write!(writer, "{}", line_source.trim_end_matches(line_trimmer))?;
             NewLine::new().emit(writer, config)?;
 
             // Write border, underline, and label
@@ -189,10 +181,8 @@ impl<'a> SourceSnippet<'a> {
 
             let prefix_span = start_line_span.with_end(self.span.start());
             let source_prefix = self.source_slice(prefix_span, &tab).expect("source_prefix");
-            let marked_span = start_line_span.with_start(self.span.start());
-            let marked_source = self
-                .source_slice(marked_span, &tab)
-                .expect("marked_source_1");
+            let line_span = start_line_span;
+            let line_source = self.source_slice(line_span, &tab).expect("line_source");
 
             if source_prefix.trim().is_empty() {
                 // Section is prefixed by empty space, so we don't need to take
@@ -205,13 +195,8 @@ impl<'a> SourceSnippet<'a> {
                 // Write underline
                 UnderlineTopLeft::new(self.mark_style).emit(writer, config)?;
 
-                // Write source prefix before marked section
-                write!(writer, " {}", source_prefix)?;
-
                 // Write marked source section
-                writer.set_color(&label_style)?;
-                write!(writer, "{}", marked_source.trim_end_matches(line_trimmer))?;
-                writer.reset()?;
+                write!(writer, " {}", line_source.trim_end_matches(line_trimmer))?;
                 NewLine::new().emit(writer, config)?;
             } else {
                 // There's source code in the prefix, so run an underline
@@ -222,13 +207,8 @@ impl<'a> SourceSnippet<'a> {
                 //   │ ╭─────────────^
                 // ```
 
-                // Write source prefix before marked section
-                write!(writer, "   {}", source_prefix)?;
-
-                // Write marked source section
-                writer.set_color(&label_style)?;
-                write!(writer, "{}", marked_source.trim_end_matches(line_trimmer))?;
-                writer.reset()?;
+                // Write source line
+                write!(writer, "   {}", line_source.trim_end_matches(line_trimmer))?;
                 NewLine::new().emit(writer, config)?;
 
                 // Write border and underline
@@ -253,14 +233,10 @@ impl<'a> SourceSnippet<'a> {
                 BorderLeft::new().emit(writer, config)?;
                 UnderlineLeft::new(self.mark_style).emit(writer, config)?;
 
-                // Write marked source section
-                let marked_span = self.line_span(line_index).expect("marked_span");
-                let marked_source = self
-                    .source_slice(marked_span, &tab)
-                    .expect("marked_source_2");
-                writer.set_color(label_style)?;
-                write!(writer, " {}", marked_source.trim_end_matches(line_trimmer))?;
-                writer.reset()?;
+                // Write source line
+                let line_span = self.line_span(line_index).expect("line_span");
+                let line_source = self.source_slice(line_span, &tab).expect("line_source_2");
+                write!(writer, " {}", line_source.trim_end_matches(line_trimmer))?;
                 NewLine::new().emit(writer, config)?;
             }
 
@@ -281,14 +257,11 @@ impl<'a> SourceSnippet<'a> {
             let marked_source = self
                 .source_slice(marked_span, &tab)
                 .expect("marked_source_3");
-            writer.set_color(label_style)?;
-            write!(writer, " {}", marked_source)?;
-            writer.reset()?;
 
-            // Write source suffix after marked section
-            let suffix_span = end_line_span.with_start(self.span.end());
-            let source_suffix = self.source_slice(suffix_span, &tab).expect("source_suffix");
-            write!(writer, "{}", source_suffix.trim_end_matches(line_trimmer))?;
+            // Write source line
+            let line_span = end_line_span;
+            let line_source = self.source_slice(line_span, &tab).expect("line_source");
+            write!(writer, " {}", line_source.trim_end_matches(line_trimmer))?;
             NewLine::new().emit(writer, config)?;
 
             // Write border, underline, and label

--- a/codespan-reporting/src/term/views/source_snippet/underline.rs
+++ b/codespan-reporting/src/term/views/source_snippet/underline.rs
@@ -188,8 +188,7 @@ impl<'a> UnderlineBottom<'a> {
 
         writer.set_color(self.mark_style.label_style(config))?;
         write!(writer, "{}", config.multiline_bottom_left_char)?;
-        let width = config.width(self.marked_source);
-        for _ in 0..width {
+        for _ in 0..config.width(self.marked_source) {
             write!(writer, "{}", config.multiline_bottom_char)?;
         }
         write!(writer, "{}", self.mark_style.multiline_caret_char(config))?;

--- a/codespan-reporting/tests/snapshots/empty_spans__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/empty_spans__rich_color.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-06-23T06:38:18.076818Z"
+created: "2019-06-23T15:00:12.571535Z"
 creator: insta@0.8.1
 source: codespan-reporting/tests/term.rs
 expression: result
@@ -8,7 +8,7 @@ expression: result
 
    {fg:Blue}┌{/}{fg:Blue}──{/} hello:1:7 {fg:Blue}───{/}
    {fg:Blue}│{/}
- {fg:Blue}1{/} {fg:Blue}│{/} Hello {fg:Green}{/}world!
+ {fg:Blue}1{/} {fg:Blue}│{/} Hello world!
    {fg:Blue}│{/}       {fg:Green}^ middle{/}
    {fg:Blue}│{/}
 
@@ -16,7 +16,7 @@ expression: result
 
    {fg:Blue}┌{/}{fg:Blue}──{/} hello:1:13 {fg:Blue}───{/}
    {fg:Blue}│{/}
- {fg:Blue}1{/} {fg:Blue}│{/} Hello world!{fg:Green}{/}
+ {fg:Blue}1{/} {fg:Blue}│{/} Hello world!
    {fg:Blue}│{/}             {fg:Green}^ end of line{/}
    {fg:Blue}│{/}
 
@@ -24,7 +24,7 @@ expression: result
 
    {fg:Blue}┌{/}{fg:Blue}──{/} hello:2:11 {fg:Blue}───{/}
    {fg:Blue}│{/}
- {fg:Blue}2{/} {fg:Blue}│{/} Bye world!{fg:Green}{/}
+ {fg:Blue}2{/} {fg:Blue}│{/} Bye world!
    {fg:Blue}│{/}           {fg:Green}^ end of file{/}
    {fg:Blue}│{/}
 

--- a/codespan-reporting/tests/snapshots/fizz_buzz__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/fizz_buzz__rich_color.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-06-23T12:32:12.586540Z"
+created: "2019-06-23T15:03:41.865131Z"
 creator: insta@0.8.1
 source: codespan-reporting/tests/term.rs
 expression: result
@@ -8,7 +8,7 @@ expression: result
 
    {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:8:12 {fg:Blue}───{/}
    {fg:Blue}│{/}
- {fg:Blue}8{/} {fg:Blue}│{/}     _ _ => {fg:Red}num{/}
+ {fg:Blue}8{/} {fg:Blue}│{/}     _ _ => num
    {fg:Blue}│{/}            {fg:Red}^^^ expected `String`, found `Nat`{/}
    {fg:Blue}│{/}
    {fg:Blue}={/} expected type `String`
@@ -16,18 +16,18 @@ expression: result
 
    {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:4:13 {fg:Blue}───{/}
    {fg:Blue}│{/}
- {fg:Blue}4{/} {fg:Blue}│{/}   fizz₁ num = {fg:Blue}case (mod num 5) (mod num 3) of{/}
+ {fg:Blue}4{/} {fg:Blue}│{/}   fizz₁ num = case (mod num 5) (mod num 3) of
    {fg:Blue}│{/} {fg:Blue}╭─────────────'{/}
- {fg:Blue}5{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}     0 0 => "FizzBuzz"{/}
- {fg:Blue}6{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}     0 _ => "Fizz"{/}
- {fg:Blue}7{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}     _ 0 => "Buzz"{/}
- {fg:Blue}8{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}     _ _ => num{/}
+ {fg:Blue}5{/} {fg:Blue}│{/} {fg:Blue}│{/}     0 0 => "FizzBuzz"
+ {fg:Blue}6{/} {fg:Blue}│{/} {fg:Blue}│{/}     0 _ => "Fizz"
+ {fg:Blue}7{/} {fg:Blue}│{/} {fg:Blue}│{/}     _ 0 => "Buzz"
+ {fg:Blue}8{/} {fg:Blue}│{/} {fg:Blue}│{/}     _ _ => num
    {fg:Blue}│{/} {fg:Blue}╰──────────────' `case` clauses have incompatible types{/}
    {fg:Blue}│{/}
 
    {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:3:15 {fg:Blue}───{/}
    {fg:Blue}│{/}
- {fg:Blue}3{/} {fg:Blue}│{/} fizz₁ : Nat → {fg:Blue}String{/}
+ {fg:Blue}3{/} {fg:Blue}│{/} fizz₁ : Nat → String
    {fg:Blue}│{/}               {fg:Blue}------ expected type `String` found here{/}
    {fg:Blue}│{/}
 
@@ -35,7 +35,7 @@ expression: result
 
     {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:15:16 {fg:Blue}───{/}
     {fg:Blue}│{/}
- {fg:Blue}15{/} {fg:Blue}│{/}         _ _ => {fg:Red}num{/}
+ {fg:Blue}15{/} {fg:Blue}│{/}         _ _ => num
     {fg:Blue}│{/}                {fg:Red}^^^ expected `String`, found `Nat`{/}
     {fg:Blue}│{/}
     {fg:Blue}={/} expected type `String`
@@ -43,29 +43,29 @@ expression: result
 
     {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:11:5 {fg:Blue}───{/}
     {fg:Blue}│{/}
- {fg:Blue}11{/} {fg:Blue}│{/} {fg:Blue}╭{/}     {fg:Blue}case (mod num 5) (mod num 3) of{/}
- {fg:Blue}12{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}         0 0 => "FizzBuzz"{/}
- {fg:Blue}13{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}         0 _ => "Fizz"{/}
- {fg:Blue}14{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}         _ 0 => "Buzz"{/}
- {fg:Blue}15{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}         _ _ => num{/}
+ {fg:Blue}11{/} {fg:Blue}│{/} {fg:Blue}╭{/}     case (mod num 5) (mod num 3) of
+ {fg:Blue}12{/} {fg:Blue}│{/} {fg:Blue}│{/}         0 0 => "FizzBuzz"
+ {fg:Blue}13{/} {fg:Blue}│{/} {fg:Blue}│{/}         0 _ => "Fizz"
+ {fg:Blue}14{/} {fg:Blue}│{/} {fg:Blue}│{/}         _ 0 => "Buzz"
+ {fg:Blue}15{/} {fg:Blue}│{/} {fg:Blue}│{/}         _ _ => num
     {fg:Blue}│{/} {fg:Blue}╰──────────────────' `case` clauses have incompatible types{/}
     {fg:Blue}│{/}
 
     {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:12:16 {fg:Blue}───{/}
     {fg:Blue}│{/}
- {fg:Blue}12{/} {fg:Blue}│{/}         0 0 => {fg:Blue}"FizzBuzz"{/}
+ {fg:Blue}12{/} {fg:Blue}│{/}         0 0 => "FizzBuzz"
     {fg:Blue}│{/}                {fg:Blue}---------- this is found to be of type `String`{/}
     {fg:Blue}│{/}
 
     {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:13:16 {fg:Blue}───{/}
     {fg:Blue}│{/}
- {fg:Blue}13{/} {fg:Blue}│{/}         0 _ => {fg:Blue}"Fizz"{/}
+ {fg:Blue}13{/} {fg:Blue}│{/}         0 _ => "Fizz"
     {fg:Blue}│{/}                {fg:Blue}------ this is found to be of type `String`{/}
     {fg:Blue}│{/}
 
     {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:14:16 {fg:Blue}───{/}
     {fg:Blue}│{/}
- {fg:Blue}14{/} {fg:Blue}│{/}         _ 0 => {fg:Blue}"Buzz"{/}
+ {fg:Blue}14{/} {fg:Blue}│{/}         _ 0 => "Buzz"
     {fg:Blue}│{/}                {fg:Blue}------ this is found to be of type `String`{/}
     {fg:Blue}│{/}
 

--- a/codespan-reporting/tests/snapshots/multifile__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/multifile__rich_color.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-06-23T06:38:18.077448Z"
+created: "2019-06-23T15:00:12.571771Z"
 creator: insta@0.8.1
 source: codespan-reporting/tests/term.rs
 expression: result
@@ -8,7 +8,7 @@ expression: result
 
    {fg:Blue}┌{/}{fg:Blue}──{/} Data/Nat.fun:7:13 {fg:Blue}───{/}
    {fg:Blue}│{/}
- {fg:Blue}7{/} {fg:Blue}│{/} {-# BUILTIN {fg:Red}NATRAL{/} Nat #-}
+ {fg:Blue}7{/} {fg:Blue}│{/} {-# BUILTIN NATRAL Nat #-}
    {fg:Blue}│{/}             {fg:Red}^^^^^^ unknown builtin{/}
    {fg:Blue}│{/}
    {fg:Blue}={/} there is a builtin with a similar name: `NATURAL`
@@ -17,7 +17,7 @@ expression: result
 
     {fg:Blue}┌{/}{fg:Blue}──{/} Data/Nat.fun:17:16 {fg:Blue}───{/}
     {fg:Blue}│{/}
- {fg:Blue}17{/} {fg:Blue}│{/} zero    - succ {fg:Yellow}n₂{/} = zero
+ {fg:Blue}17{/} {fg:Blue}│{/} zero    - succ n₂ = zero
     {fg:Blue}│{/}                {fg:Yellow}^^ unused parameter{/}
     {fg:Blue}│{/}
     {fg:Blue}={/} consider using a wildcard pattern: `_`
@@ -26,13 +26,13 @@ expression: result
 
    {fg:Blue}┌{/}{fg:Blue}──{/} Test.fun:4:11 {fg:Blue}───{/}
    {fg:Blue}│{/}
- {fg:Blue}4{/} {fg:Blue}│{/} _ = 123 + {fg:Red}"hello"{/}
+ {fg:Blue}4{/} {fg:Blue}│{/} _ = 123 + "hello"
    {fg:Blue}│{/}           {fg:Red}^^^^^^^ expected `Nat`, found `String`{/}
    {fg:Blue}│{/}
 
     {fg:Blue}┌{/}{fg:Blue}──{/} Data/Nat.fun:11:1 {fg:Blue}───{/}
     {fg:Blue}│{/}
- {fg:Blue}11{/} {fg:Blue}│{/} {fg:Blue}_+_ : Nat → Nat → Nat{/}
+ {fg:Blue}11{/} {fg:Blue}│{/} _+_ : Nat → Nat → Nat
     {fg:Blue}│{/} {fg:Blue}--------------------- based on the definition of `_+_`{/}
     {fg:Blue}│{/}
 


### PR DESCRIPTION
This used to be necessary before we had the snakey underlines (#98), but now it's less useful, especially in multiline sections. It will also make it harder to implement overlapping error messages like in rustc (#100).

Before:

<img width="399" alt="Screen Shot 2019-06-24 at 9 23 20 am" src="https://user-images.githubusercontent.com/695077/59983350-d3bec600-9661-11e9-85ef-40eaa44705e4.png">

After:

<img width="410" alt="Screen Shot 2019-06-24 at 9 23 07 am" src="https://user-images.githubusercontent.com/695077/59983344-c570aa00-9661-11e9-8770-1839bf220b80.png">