### PR TITLE
Remove Span::{with_start, with_end} to improve clarity

### DIFF
--- a/codespan-reporting/src/term/views/source_snippet/mod.rs
+++ b/codespan-reporting/src/term/views/source_snippet/mod.rs
@@ -139,14 +139,15 @@ impl<'a> SourceSnippet<'a> {
             // ```
 
             let prefix_source = {
-                let span = start_line_span.with_end(self.span.start());
+                let span = Span::new(start_line_span.start(), self.span.start());
                 self.source_slice(span, &tab).expect("prefix_source")
             };
-            let highlighted_source = self
-                .source_slice(self.span, &tab)
-                .expect("highlighted_source");
+            let highlighted_source = {
+                let span = self.span;
+                self.source_slice(span, &tab).expect("highlighted_source")
+            };
             let suffix_source = {
-                let span = end_line_span.with_start(self.span.end());
+                let span = Span::new(self.span.end(), end_line_span.end());
                 self.source_slice(span, &tab).expect("suffix_source")
             };
 
@@ -188,11 +189,11 @@ impl<'a> SourceSnippet<'a> {
             // ```
 
             let prefix_source = {
-                let span = start_line_span.with_end(self.span.start());
+                let span = Span::new(start_line_span.start(), self.span.start());
                 self.source_slice(span, &tab).expect("prefix_source")
             };
             let highlighted_source = {
-                let span = start_line_span.with_start(self.span.start());
+                let span = Span::new(self.span.start(), start_line_span.end());
                 self.source_slice(span, &tab).expect("highlighted_source_1")
             };
 
@@ -277,11 +278,11 @@ impl<'a> SourceSnippet<'a> {
             // ```
 
             let highlighted_source = {
-                let span = end_line_span.with_end(self.span.end());
+                let span = Span::new(end_line_span.start(), self.span.end());
                 self.source_slice(span, &tab).expect("highlighted_source_3")
             };
             let suffix_source = {
-                let span = end_line_span.with_start(self.span.end());
+                let span = Span::new(self.span.end(), end_line_span.end());
                 self.source_slice(span, &tab).expect("suffix_source")
             };
 

--- a/codespan/src/span.rs
+++ b/codespan/src/span.rs
@@ -57,32 +57,6 @@ impl Span {
         Span::new(self.start(), other.end())
     }
 
-    /// Return a new span with the start set to the given byte index.
-    ///
-    /// ```rust
-    /// use codespan::{ByteIndex, Span};
-    ///
-    /// let span = Span::new(5, 10);
-    ///
-    /// assert_eq!(span.with_start(0), Span::new(0, 10));
-    /// ```
-    pub fn with_start(&self, start: impl Into<ByteIndex>) -> Span {
-        Span::new(start, self.end())
-    }
-
-    /// Return a new span with the end set to the given byte index.
-    ///
-    /// ```rust
-    /// use codespan::{ByteIndex, Span};
-    ///
-    /// let span = Span::new(0, 5);
-    ///
-    /// assert_eq!(span.with_end(10), Span::new(0, 10));
-    /// ```
-    pub fn with_end(&self, end: impl Into<ByteIndex>) -> Span {
-        Span::new(self.start(), end)
-    }
-
     /// Get the starting byte index.
     ///
     /// ```rust


### PR DESCRIPTION
These were pretty confusing - and the full version isn’t that much longer. In particular:

```rust
let span = end_line_span.with_start(self.span.end());
```

This is confusing because the 'start' actually goes after the span. I had to re-read the logic a few times to understand it! This is much clearer on the other hand:

```rust
let span = Span::new(self.span.end(), end_line_span.end());
```