### PR TITLE
Remove derive-more from codespan and codespan-lsp

### DIFF
--- a/codespan-lsp/Cargo.toml
+++ b/codespan-lsp/Cargo.toml
@@ -12,6 +12,5 @@ edition = "2018"
 [dependencies]
 codespan = { version = "0.3.0", path = "../codespan" } # CODESPAN
 codespan-reporting = { version = "0.3.0", path = "../codespan-reporting/" } # CODESPAN
-derive_more = "0.15"
 lsp-types = "0.58"
 url = "1"

--- a/codespan-lsp/src/lib.rs
+++ b/codespan-lsp/src/lib.rs
@@ -6,14 +6,12 @@ use codespan::{
 };
 use codespan_reporting::diagnostic::{Diagnostic, Severity};
 use lsp_types as lsp;
-use std::error;
+use std::{error, fmt};
 use url::Url;
 
-#[derive(derive_more::Display, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
-    #[display(fmt = "Unable to correlate filename `{}` to url", _0)]
     UnableToCorrelateFilename(String),
-    #[display(fmt = "Column out of bounds - given: {}, max: {}", given, max)]
     ColumnOutOfBounds {
         given: ColumnIndex,
         max: ColumnIndex,
@@ -21,6 +19,22 @@ pub enum Error {
     Location(LocationError),
     LineIndexOutOfBounds(LineIndexOutOfBoundsError),
     SpanOutOfBounds(SpanOutOfBoundsError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::UnableToCorrelateFilename(s) => {
+                write!(f, "Unable to correlate filename `{}` to url", s)
+            },
+            Error::ColumnOutOfBounds { given, max } => {
+                write!(f, "Column out of bounds - given: {}, max: {}", given, max)
+            },
+            Error::Location(e) => e.fmt(f),
+            Error::LineIndexOutOfBounds(e) => e.fmt(f),
+            Error::SpanOutOfBounds(e) => e.fmt(f),
+        }
+    }
 }
 
 impl From<LocationError> for Error {

--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -11,7 +11,6 @@ documentation = "https://docs.rs/codespan"
 edition = "2018"
 
 [dependencies]
-derive_more = "0.15"
 heapsize = { version = "0.4", optional = true }
 heapsize_derive = { version = "0.1", optional = true }
 serde = { version = "1", optional = true, features = ["derive"]}

--- a/codespan/src/file.rs
+++ b/codespan/src/file.rs
@@ -1,11 +1,10 @@
 #[cfg(feature = "serialization")]
 use serde::{Deserialize, Serialize};
-use std::error;
+use std::{error, fmt};
 
 use crate::{ByteIndex, ColumnIndex, LineIndex, LineOffset, Location, RawIndex, Span};
 
-#[derive(derive_more::Display, Debug, PartialEq)]
-#[display(fmt = "Line index out of bounds - given: {}, max: {}", given, max)]
+#[derive(Debug, PartialEq)]
 pub struct LineIndexOutOfBoundsError {
     pub given: LineIndex,
     pub max: LineIndex,
@@ -13,24 +12,56 @@ pub struct LineIndexOutOfBoundsError {
 
 impl error::Error for LineIndexOutOfBoundsError {}
 
-#[derive(derive_more::Display, Debug, PartialEq)]
+impl fmt::Display for LineIndexOutOfBoundsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Line index out of bounds - given: {}, max: {}",
+            self.given, self.max
+        )
+    }
+}
+
+#[derive(Debug, PartialEq)]
 pub enum LocationError {
-    #[display(fmt = "Byte index out of bounds - given: {}, span: {}", given, span)]
     OutOfBounds { given: ByteIndex, span: Span },
-    #[display(fmt = "Byte index within character boundary - given: {}", given)]
     InvalidCharBoundary { given: ByteIndex },
 }
 
 impl error::Error for LocationError {}
 
-#[derive(derive_more::Display, Debug, PartialEq)]
-#[display(fmt = "Span out of bounds - given: {}, span: {}", given, span)]
+impl fmt::Display for LocationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LocationError::OutOfBounds { given, span } => write!(
+                f,
+                "Byte index out of bounds - given: {}, span: {}",
+                given, span
+            ),
+            LocationError::InvalidCharBoundary { given } => {
+                write!(f, "Byte index within character boundary - given: {}", given)
+            },
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
 pub struct SpanOutOfBoundsError {
     pub given: Span,
     pub span: Span,
 }
 
 impl error::Error for SpanOutOfBoundsError {}
+
+impl fmt::Display for SpanOutOfBoundsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Span out of bounds - given: {}, span: {}",
+            self.given, self.span
+        )
+    }
+}
 
 /// A handle that points to a file in the database.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/codespan/src/index.rs
+++ b/codespan/src/index.rs
@@ -13,7 +13,7 @@ pub type RawIndex = u32;
 pub type RawOffset = i64;
 
 /// A zero-indexed line offset into a source file
-#[derive(derive_more::Display, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "memory_usage", derive(heapsize_derive::HeapSizeOf))]
 pub struct LineIndex(pub RawIndex);
@@ -51,8 +51,14 @@ impl fmt::Debug for LineIndex {
     }
 }
 
+impl fmt::Display for LineIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// A 1-indexed line number. Useful for pretty printing source locations.
-#[derive(derive_more::Display, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "memory_usage", derive(heapsize_derive::HeapSizeOf))]
 pub struct LineNumber(RawIndex);
@@ -65,8 +71,14 @@ impl fmt::Debug for LineNumber {
     }
 }
 
+impl fmt::Display for LineNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// A line offset in a source file
-#[derive(derive_more::Display, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "memory_usage", derive(heapsize_derive::HeapSizeOf))]
 pub struct LineOffset(pub RawOffset);
@@ -85,8 +97,14 @@ impl fmt::Debug for LineOffset {
     }
 }
 
+impl fmt::Display for LineOffset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// A zero-indexed column offset into a source file
-#[derive(derive_more::Display, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "memory_usage", derive(heapsize_derive::HeapSizeOf))]
 pub struct ColumnIndex(pub RawIndex);
@@ -124,8 +142,14 @@ impl fmt::Debug for ColumnIndex {
     }
 }
 
+impl fmt::Display for ColumnIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// A 1-indexed column number. Useful for pretty printing source locations.
-#[derive(derive_more::Display, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "memory_usage", derive(heapsize_derive::HeapSizeOf))]
 pub struct ColumnNumber(RawIndex);
@@ -135,6 +159,12 @@ impl fmt::Debug for ColumnNumber {
         write!(f, "ColumnNumber(")?;
         self.0.fmt(f)?;
         write!(f, ")")
+    }
+}
+
+impl fmt::Display for ColumnNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 
@@ -165,7 +195,7 @@ impl fmt::Display for ColumnOffset {
 }
 
 /// A byte position in a source file.
-#[derive(derive_more::Display, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "memory_usage", derive(heapsize_derive::HeapSizeOf))]
 pub struct ByteIndex(pub RawIndex);
@@ -191,8 +221,14 @@ impl fmt::Debug for ByteIndex {
     }
 }
 
+impl fmt::Display for ByteIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// A byte offset in a source file
-#[derive(derive_more::Display, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "memory_usage", derive(heapsize_derive::HeapSizeOf))]
 pub struct ByteOffset(pub RawOffset);
@@ -244,6 +280,12 @@ impl fmt::Debug for ByteOffset {
         write!(f, "ByteOffset(")?;
         self.0.fmt(f)?;
         write!(f, ")")
+    }
+}
+
+impl fmt::Display for ByteOffset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 


### PR DESCRIPTION
This PR removes `derive-more` from codespan and codespan-lsp. The motivation is to keep dependency tree lean, at least for the foundational crate with spans. To illustrate, the following is `codespan` with default-features set to false.

Before:
```
+-- codespan v0.3.0 (https://github.com/brendanzab/codespan?rev=0a5d9a0#0a5d9a0d)
    +-- derive_more v0.15.0
    ¦   +-- lazy_static v1.3.0
    ¦   +-- proc-macro2 v0.4.30
    ¦   ¦   +-- unicode-xid v0.1.0
    ¦   +-- quote v0.6.12
    ¦   ¦   +-- proc-macro2 v0.4.30 (*)
    ¦   +-- regex v1.1.7
    ¦   ¦   +-- aho-corasick v0.7.4
    ¦   ¦   ¦   +-- memchr v2.2.0
    ¦   ¦   +-- memchr v2.2.0 (*)
    ¦   ¦   +-- regex-syntax v0.6.7
    ¦   ¦   ¦   +-- ucd-util v0.1.3
    ¦   ¦   +-- thread_local v0.3.6
    ¦   ¦   ¦   +-- lazy_static v1.3.0 (*)
    ¦   ¦   +-- utf8-ranges v1.0.3
    ¦   +-- syn v0.15.39
    ¦       +-- proc-macro2 v0.4.30 (*)
    ¦       +-- quote v0.6.12 (*)
    ¦       +-- unicode-xid v0.1.0 (*)
    ¦   [build-dependencies]
    ¦   +-- rustc_version v0.2.3
    ¦       +-- semver v0.9.0
    ¦           +-- semver-parser v0.7.0
    +-- unicode-segmentation v1.3.0
```

After:
```
+-- codespan v0.3.0 (https://github.com/memoryruins/codespan?branch=derive-less#e0f8b046)
    +-- unicode-segmentation v1.3.0
```

which brings the dep tree to a similar count as e.g. [text_unit](https://crates.io/crates/text_unit)!

The removal of `failure` in #68 also helped in this regard :)
The current published codespan (0.3.0) on crates.io has the following dependency tree:
```
+-- codespan v0.3.0
    +-- failure v0.1.5
    ¦   +-- backtrace v0.3.32
    ¦   ¦   +-- backtrace-sys v0.1.30
    ¦   ¦   ¦   +-- libc v0.2.58
    ¦   ¦   ¦   [build-dependencies]
    ¦   ¦   ¦   +-- cc v1.0.37
    ¦   ¦   +-- cfg-if v0.1.9
    ¦   ¦   +-- libc v0.2.58 (*)
    ¦   ¦   +-- rustc-demangle v0.1.15
    ¦   +-- failure_derive v0.1.5
    ¦       +-- proc-macro2 v0.4.30
    ¦       ¦   +-- unicode-xid v0.1.0
    ¦       +-- quote v0.6.12
    ¦       ¦   +-- proc-macro2 v0.4.30 (*)
    ¦       +-- syn v0.15.39
    ¦       ¦   +-- proc-macro2 v0.4.30 (*)
    ¦       ¦   +-- quote v0.6.12 (*)
    ¦       ¦   +-- unicode-xid v0.1.0 (*)
    ¦       +-- synstructure v0.10.2
    ¦           +-- proc-macro2 v0.4.30 (*)
    ¦           +-- quote v0.6.12 (*)
    ¦           +-- syn v0.15.39 (*)
    ¦           +-- unicode-xid v0.1.0 (*)
    +-- itertools v0.8.0
        +-- either v1.5.2
```