### PR TITLE
Implement Default for Span

### DIFF
--- a/codespan/src/span.rs
+++ b/codespan/src/span.rs
@@ -84,6 +84,12 @@ impl Span {
     }
 }
 
+impl Default for Span {
+    fn default() -> Span {
+        Span::initial()
+    }
+}
+
 impl fmt::Display for Span {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(


### PR DESCRIPTION
### Changed

* Implement `std::default::Default` for `Span` to aid API ergonomics.

Closes #117.