### PR TITLE
Group snippets by file

### DIFF
--- a/codespan-reporting/src/term/config.rs
+++ b/codespan-reporting/src/term/config.rs
@@ -192,6 +192,9 @@ pub struct Chars {
     /// The character to use for the left border of the source.
     /// Defaults to: `'│'`.
     pub source_border_left: char,
+    /// The character to use for the left border break of the source.
+    /// Defaults to: `'·'`.
+    pub source_border_left_break: char,
 
     /// The character to use for the note bullet.
     /// Defaults to: `'='`.
@@ -233,6 +236,7 @@ impl Default for Chars {
             source_border_top_left: '┌',
             source_border_top: '─',
             source_border_left: '│',
+            source_border_left_break: '·',
 
             note_bullet: '=',
 

--- a/codespan-reporting/src/term/views/diagnostic.rs
+++ b/codespan-reporting/src/term/views/diagnostic.rs
@@ -19,14 +19,42 @@ impl<'a> RichDiagnostic<'a> {
     }
 
     pub fn emit(&self, writer: &mut impl WriteColor, config: &Config) -> io::Result<()> {
+        use std::collections::BTreeMap;
+
+        use super::MarkStyle;
+
         Header::new(self.diagnostic).emit(writer, config)?;
         NewLine::new().emit(writer, config)?;
 
-        SourceSnippet::new_primary(self.files, &self.diagnostic).emit(writer, config)?;
+        let primary_label = &self.diagnostic.primary_label;
+        let primary_file_id = self.diagnostic.primary_label.file_id;
+        let severity = self.diagnostic.severity;
+        let notes = &self.diagnostic.notes;
+
+        // Group labels by file
+
+        let mut label_groups = BTreeMap::new();
+
+        label_groups
+            .entry(primary_file_id)
+            .or_insert(vec![])
+            .push((primary_label, MarkStyle::Primary(severity)));
+
+        for secondary_label in &self.diagnostic.secondary_labels {
+            label_groups
+                .entry(secondary_label.file_id)
+                .or_insert(vec![])
+                .push((secondary_label, MarkStyle::Secondary));
+        }
+
+        // Emit the snippets, starting with the one that contains the primary label
+
+        let labels = label_groups.remove(&primary_file_id).unwrap_or(vec![]);
+        SourceSnippet::new(self.files, primary_file_id, labels, notes).emit(writer, config)?;
         NewLine::new().emit(writer, config)?;
 
-        for label in &self.diagnostic.secondary_labels {
-            SourceSnippet::new_secondary(self.files, &label).emit(writer, config)?;
+        for (file_id, labels) in label_groups {
+            SourceSnippet::new(self.files, file_id, labels, &[]).emit(writer, config)?;
             NewLine::new().emit(writer, config)?;
         }
 

--- a/codespan-reporting/src/term/views/source_snippet/border.rs
+++ b/codespan-reporting/src/term/views/source_snippet/border.rs
@@ -57,3 +57,20 @@ impl BorderLeft {
         Ok(())
     }
 }
+
+/// The left-hand border of a source line.
+pub struct BorderLeftBreak {}
+
+impl BorderLeftBreak {
+    pub fn new() -> BorderLeftBreak {
+        BorderLeftBreak {}
+    }
+
+    pub fn emit(&self, writer: &mut impl WriteColor, config: &Config) -> io::Result<()> {
+        writer.set_color(&config.styles.source_border)?;
+        write!(writer, "{}", config.chars.source_border_left_break)?;
+        writer.reset()?;
+
+        Ok(())
+    }
+}

--- a/codespan-reporting/src/term/views/source_snippet/mod.rs
+++ b/codespan-reporting/src/term/views/source_snippet/mod.rs
@@ -125,10 +125,6 @@ impl<'a> SourceSnippet<'a> {
         BorderLeft::new().emit(writer, config)?;
         NewLine::new().emit(writer, config)?;
 
-        fn trim_breaks(s: &str) -> &str {
-            s.trim_end_matches(|ch| ch == '\r' || ch == '\n')
-        }
-
         // Write underlined source section
         if start.line == end.line {
             // Single line
@@ -160,7 +156,7 @@ impl<'a> SourceSnippet<'a> {
             writer.set_color(label_style)?;
             write!(writer, "{}", highlighted_source)?;
             writer.reset()?;
-            write!(writer, "{}", trim_breaks(&suffix_source))?;
+            write!(writer, "{}", suffix_source.trim_end())?;
 
             NewLine::new().emit(writer, config)?;
 
@@ -213,7 +209,7 @@ impl<'a> SourceSnippet<'a> {
                 // Write source line
                 write!(writer, " {}", prefix_source)?;
                 writer.set_color(&label_style)?;
-                write!(writer, "{}", trim_breaks(&highlighted_source))?;
+                write!(writer, "{}", highlighted_source.trim_end())?;
                 writer.reset()?;
                 NewLine::new().emit(writer, config)?;
             } else {
@@ -232,7 +228,7 @@ impl<'a> SourceSnippet<'a> {
                 // Write source line
                 write!(writer, "   {}", prefix_source)?;
                 writer.set_color(&label_style)?;
-                write!(writer, "{}", trim_breaks(&highlighted_source))?;
+                write!(writer, "{}", highlighted_source.trim_end())?;
                 writer.reset()?;
                 NewLine::new().emit(writer, config)?;
 
@@ -265,7 +261,7 @@ impl<'a> SourceSnippet<'a> {
 
                 // Write highlighted source
                 writer.set_color(label_style)?;
-                write!(writer, " {}", trim_breaks(&highlighted_source))?;
+                write!(writer, " {}", highlighted_source.trim_end())?;
                 writer.reset()?;
                 NewLine::new().emit(writer, config)?;
             }
@@ -295,7 +291,7 @@ impl<'a> SourceSnippet<'a> {
             writer.set_color(label_style)?;
             write!(writer, " {}", highlighted_source)?;
             writer.reset()?;
-            write!(writer, "{}", trim_breaks(&suffix_source))?;
+            write!(writer, "{}", suffix_source.trim_end())?;
             NewLine::new().emit(writer, config)?;
 
             // Write border, underline, and label

--- a/codespan-reporting/src/term/views/source_snippet/mod.rs
+++ b/codespan-reporting/src/term/views/source_snippet/mod.rs
@@ -12,7 +12,7 @@ mod gutter;
 mod note;
 mod underline;
 
-use self::border::{BorderLeft, BorderTop, BorderTopLeft};
+use self::border::{BorderLeft, BorderLeftBreak, BorderTop, BorderTopLeft};
 use self::gutter::Gutter;
 use self::note::Note;
 use self::underline::{Underline, UnderlineBottom, UnderlineLeft, UnderlineTop, UnderlineTopLeft};
@@ -111,7 +111,7 @@ impl<'a> SourceSnippet<'a> {
         NewLine::new().emit(writer, config)?;
 
         // TODO: Better grouping
-        for (label, mark_style) in &self.spans {
+        for (i, (label, mark_style)) in self.spans.iter().enumerate() {
             let start = self.location(label.span.start()).expect("location_start");
             let end = self.location(label.span.end()).expect("location_end");
             let start_line_span = self.line_span(start.line).expect("start_line_span");
@@ -130,7 +130,10 @@ impl<'a> SourceSnippet<'a> {
 
             // Write initial border
             Gutter::new(None, gutter_padding).emit(writer, config)?;
-            BorderLeft::new().emit(writer, config)?;
+            match i {
+                0 => BorderLeft::new().emit(writer, config)?,
+                _ => BorderLeftBreak::new().emit(writer, config)?,
+            }
             NewLine::new().emit(writer, config)?;
 
             // Write underlined source section
@@ -306,7 +309,7 @@ impl<'a> SourceSnippet<'a> {
                 UnderlineBottom::new(*mark_style, &highlighted_source, &label.message)
                     .emit(writer, config)?;
                 NewLine::new().emit(writer, config)?;
-            };
+            }
         }
 
         // Write final border

--- a/codespan-reporting/src/term/views/source_snippet/mod.rs
+++ b/codespan-reporting/src/term/views/source_snippet/mod.rs
@@ -2,7 +2,7 @@ use codespan::{ByteIndex, FileId, Files, LineIndex, Location, Span};
 use std::io;
 use termcolor::WriteColor;
 
-use crate::diagnostic::{Diagnostic, Label};
+use crate::diagnostic::Label;
 use crate::term::Config;
 
 use super::{Locus, NewLine};
@@ -15,9 +15,9 @@ mod underline;
 use self::border::{BorderLeft, BorderTop, BorderTopLeft};
 use self::gutter::Gutter;
 use self::note::Note;
-use self::underline::{
-    MarkStyle, Underline, UnderlineBottom, UnderlineLeft, UnderlineTop, UnderlineTopLeft,
-};
+use self::underline::{Underline, UnderlineBottom, UnderlineLeft, UnderlineTop, UnderlineTopLeft};
+
+pub use self::underline::MarkStyle;
 
 /// An underlined snippet of source code.
 ///
@@ -33,37 +33,38 @@ use self::underline::{
 pub struct SourceSnippet<'a> {
     files: &'a Files,
     file_id: FileId,
-    span: Span,
-    message: &'a str,
-    mark_style: MarkStyle,
+    spans: Vec<(&'a Label, MarkStyle)>,
     notes: &'a [String],
 }
 
 impl<'a> SourceSnippet<'a> {
-    pub fn new_primary(files: &'a Files, diagnostic: &'a Diagnostic) -> SourceSnippet<'a> {
+    pub fn new(
+        files: &'a Files,
+        file_id: FileId,
+        spans: Vec<(&'a Label, MarkStyle)>,
+        notes: &'a [String],
+    ) -> SourceSnippet<'a> {
         SourceSnippet {
             files,
-            file_id: diagnostic.primary_label.file_id,
-            span: diagnostic.primary_label.span,
-            message: &diagnostic.primary_label.message,
-            mark_style: MarkStyle::Primary(diagnostic.severity),
-            notes: &diagnostic.notes,
-        }
-    }
-
-    pub fn new_secondary(files: &'a Files, label: &'a Label) -> SourceSnippet<'a> {
-        SourceSnippet {
-            files,
-            file_id: label.file_id,
-            span: label.span,
-            message: &label.message,
-            mark_style: MarkStyle::Secondary,
-            notes: &[],
+            file_id,
+            spans,
+            notes,
         }
     }
 
     fn file_name(&self) -> &'a str {
         self.files.name(self.file_id)
+    }
+
+    fn span(&self) -> Span {
+        let span = self.spans.iter().fold(None::<Span>, |acc, (label, _)| {
+            Some(acc.map_or(label.span, |acc| {
+                let start = std::cmp::min(acc.start(), label.span.start());
+                let end = std::cmp::max(acc.end(), label.span.end());
+                Span::new(start, end)
+            }))
+        });
+        span.unwrap_or(Span::initial())
     }
 
     fn location(&self, byte_index: ByteIndex) -> Result<Location, impl std::error::Error> {
@@ -83,12 +84,10 @@ impl<'a> SourceSnippet<'a> {
     }
 
     pub fn emit(&self, writer: &mut impl WriteColor, config: &Config) -> io::Result<()> {
-        let start = self.location(self.span.start()).expect("location_start");
-        let end = self.location(self.span.end()).expect("location_end");
-        let start_line_span = self.line_span(start.line).expect("start_line_span");
-        let end_line_span = self.line_span(end.line).expect("end_line_span");
+        let span = self.span();
+        let start = self.location(span.start()).expect("location_start");
+        let end = self.location(span.end()).expect("location_end");
 
-        let label_style = self.mark_style.label_style(config);
         // Use the length of the last line number as the gutter padding
         let gutter_padding = format!("{}", end.line.number()).len();
         // Cache the tabs we'll be using to pad the source strings.
@@ -111,196 +110,204 @@ impl<'a> SourceSnippet<'a> {
         BorderTop::new(3).emit(writer, config)?;
         NewLine::new().emit(writer, config)?;
 
-        // Code snippet
-        //
-        // ```text
-        //   │
-        // 2 │ (+ test "")
-        //   │         ^^ expected `Int` but found `String`
-        //   │
-        // ```
+        // TODO: Better grouping
+        for (label, mark_style) in &self.spans {
+            let start = self.location(label.span.start()).expect("location_start");
+            let end = self.location(label.span.end()).expect("location_end");
+            let start_line_span = self.line_span(start.line).expect("start_line_span");
+            let end_line_span = self.line_span(end.line).expect("end_line_span");
 
-        // Write initial border
-        Gutter::new(None, gutter_padding).emit(writer, config)?;
-        BorderLeft::new().emit(writer, config)?;
-        NewLine::new().emit(writer, config)?;
+            let label_style = mark_style.label_style(config);
 
-        // Write underlined source section
-        if start.line == end.line {
-            // Single line
+            // Code snippet
             //
             // ```text
+            //   │
             // 2 │ (+ test "")
             //   │         ^^ expected `Int` but found `String`
+            //   │
             // ```
 
-            let prefix_source = {
-                let span = Span::new(start_line_span.start(), self.span.start());
-                self.source_slice(span, &tab).expect("prefix_source")
-            };
-            let highlighted_source = {
-                let span = self.span;
-                self.source_slice(span, &tab).expect("highlighted_source")
-            };
-            let suffix_source = {
-                let span = Span::new(self.span.end(), end_line_span.end());
-                self.source_slice(span, &tab).expect("suffix_source")
-            };
-
-            // Write line number and border
-            Gutter::new(start.line.number(), gutter_padding).emit(writer, config)?;
-            BorderLeft::new().emit(writer, config)?;
-
-            // Write line source
-            write!(writer, " {}", prefix_source)?;
-            writer.set_color(label_style)?;
-            write!(writer, "{}", highlighted_source)?;
-            writer.reset()?;
-            write!(writer, "{}", suffix_source.trim_end())?;
-
-            NewLine::new().emit(writer, config)?;
-
-            // Write border, underline, and label
+            // Write initial border
             Gutter::new(None, gutter_padding).emit(writer, config)?;
             BorderLeft::new().emit(writer, config)?;
-            Underline::new(
-                self.mark_style,
-                &prefix_source,
-                &highlighted_source,
-                self.message,
-            )
-            .emit(writer, config)?;
             NewLine::new().emit(writer, config)?;
-        } else {
-            // Multiple lines
-            //
-            // ```text
-            // 4 │   fizz₁ num = case (mod num 5) (mod num 3) of
-            //   │ ╭─────────────^
-            // 5 │ │     0 0 => "FizzBuzz"
-            // 6 │ │     0 _ => "Fizz"
-            // 7 │ │     _ 0 => "Buzz"
-            // 8 │ │     _ _ => num
-            //   │ ╰──────────────^ `case` clauses have incompatible types
-            // ```
 
-            let prefix_source = {
-                let span = Span::new(start_line_span.start(), self.span.start());
-                self.source_slice(span, &tab).expect("prefix_source")
-            };
-            let highlighted_source = {
-                let span = Span::new(self.span.start(), start_line_span.end());
-                self.source_slice(span, &tab).expect("highlighted_source_1")
-            };
-
-            if prefix_source.trim().is_empty() {
-                // Section is prefixed by empty space, so we don't need to take
-                // up a new line.
+            // Write underlined source section
+            if start.line == end.line {
+                // Single line
                 //
                 // ```text
-                // 4 │ ╭     case (mod num 5) (mod num 3) of
+                // 2 │ (+ test "")
+                //   │         ^^ expected `Int` but found `String`
                 // ```
 
-                // Write line number, border, and underline
-                Gutter::new(start.line.number(), gutter_padding).emit(writer, config)?;
-                BorderLeft::new().emit(writer, config)?;
-                UnderlineTopLeft::new(self.mark_style).emit(writer, config)?;
-
-                // Write source line
-                write!(writer, " {}", prefix_source)?;
-                writer.set_color(&label_style)?;
-                write!(writer, "{}", highlighted_source.trim_end())?;
-                writer.reset()?;
-                NewLine::new().emit(writer, config)?;
-            } else {
-                // There's source code in the prefix, so run an underline
-                // underneath it to get to the start of the span.
-                //
-                // ```text
-                // 4 │   fizz₁ num = case (mod num 5) (mod num 3) of
-                //   │ ╭─────────────^
-                // ```
+                let prefix_source = {
+                    let span = Span::new(start_line_span.start(), label.span.start());
+                    self.source_slice(span, &tab).expect("prefix_source")
+                };
+                let highlighted_source = {
+                    let span = label.span;
+                    self.source_slice(span, &tab).expect("highlighted_source")
+                };
+                let suffix_source = {
+                    let span = Span::new(label.span.end(), end_line_span.end());
+                    self.source_slice(span, &tab).expect("suffix_source")
+                };
 
                 // Write line number and border
                 Gutter::new(start.line.number(), gutter_padding).emit(writer, config)?;
                 BorderLeft::new().emit(writer, config)?;
 
-                // Write source line
-                write!(writer, "   {}", prefix_source)?;
-                writer.set_color(&label_style)?;
-                write!(writer, "{}", highlighted_source.trim_end())?;
+                // Write line source
+                write!(writer, " {}", prefix_source)?;
+                writer.set_color(label_style)?;
+                write!(writer, "{}", highlighted_source)?;
                 writer.reset()?;
+                write!(writer, "{}", suffix_source.trim_end())?;
                 NewLine::new().emit(writer, config)?;
 
-                // Write border and underline
+                // Write border, underline, and label
                 Gutter::new(None, gutter_padding).emit(writer, config)?;
                 BorderLeft::new().emit(writer, config)?;
-                UnderlineTop::new(self.mark_style, &prefix_source).emit(writer, config)?;
+                Underline::new(
+                    *mark_style,
+                    &prefix_source,
+                    &highlighted_source,
+                    &label.message,
+                )
+                .emit(writer, config)?;
                 NewLine::new().emit(writer, config)?;
-            }
+            } else {
+                // Multiple lines
+                //
+                // ```text
+                // 4 │   fizz₁ num = case (mod num 5) (mod num 3) of
+                //   │ ╭─────────────^
+                // 5 │ │     0 0 => "FizzBuzz"
+                // 6 │ │     0 _ => "Fizz"
+                // 7 │ │     _ 0 => "Buzz"
+                // 8 │ │     _ _ => num
+                //   │ ╰──────────────^ `case` clauses have incompatible types
+                // ```
 
-            // Write highlighted lines
-            //
-            // ```text
-            // 5 │ │     0 0 => "FizzBuzz"
-            // 6 │ │     0 _ => "Fizz"
-            // 7 │ │     _ 0 => "Buzz"
-            // ```
-            for line_index in ((start.line.to_usize() + 1)..end.line.to_usize())
-                .map(|i| LineIndex::from(i as u32))
-            {
+                let prefix_source = {
+                    let span = Span::new(start_line_span.start(), label.span.start());
+                    self.source_slice(span, &tab).expect("prefix_source")
+                };
                 let highlighted_source = {
-                    let span = self.line_span(line_index).expect("highlighted_span");
-                    self.source_slice(span, &tab).expect("highlighted_source_2")
+                    let span = Span::new(label.span.start(), start_line_span.end());
+                    self.source_slice(span, &tab).expect("highlighted_source_1")
+                };
+
+                if prefix_source.trim().is_empty() {
+                    // Section is prefixed by empty space, so we don't need to take
+                    // up a new line.
+                    //
+                    // ```text
+                    // 4 │ ╭     case (mod num 5) (mod num 3) of
+                    // ```
+
+                    // Write line number, border, and underline
+                    Gutter::new(start.line.number(), gutter_padding).emit(writer, config)?;
+                    BorderLeft::new().emit(writer, config)?;
+                    UnderlineTopLeft::new(*mark_style).emit(writer, config)?;
+
+                    // Write source line
+                    write!(writer, " {}", prefix_source)?;
+                    writer.set_color(&label_style)?;
+                    write!(writer, "{}", highlighted_source.trim_end())?;
+                    writer.reset()?;
+                    NewLine::new().emit(writer, config)?;
+                } else {
+                    // There's source code in the prefix, so run an underline
+                    // underneath it to get to the start of the span.
+                    //
+                    // ```text
+                    // 4 │   fizz₁ num = case (mod num 5) (mod num 3) of
+                    //   │ ╭─────────────^
+                    // ```
+
+                    // Write line number and border
+                    Gutter::new(start.line.number(), gutter_padding).emit(writer, config)?;
+                    BorderLeft::new().emit(writer, config)?;
+
+                    // Write source line
+                    write!(writer, "   {}", prefix_source)?;
+                    writer.set_color(&label_style)?;
+                    write!(writer, "{}", highlighted_source.trim_end())?;
+                    writer.reset()?;
+                    NewLine::new().emit(writer, config)?;
+
+                    // Write border and underline
+                    Gutter::new(None, gutter_padding).emit(writer, config)?;
+                    BorderLeft::new().emit(writer, config)?;
+                    UnderlineTop::new(*mark_style, &prefix_source).emit(writer, config)?;
+                    NewLine::new().emit(writer, config)?;
+                }
+
+                // Write highlighted lines
+                //
+                // ```text
+                // 5 │ │     0 0 => "FizzBuzz"
+                // 6 │ │     0 _ => "Fizz"
+                // 7 │ │     _ 0 => "Buzz"
+                // ```
+                for line_index in ((start.line.to_usize() + 1)..end.line.to_usize())
+                    .map(|i| LineIndex::from(i as u32))
+                {
+                    let highlighted_source = {
+                        let span = self.line_span(line_index).expect("highlighted_span");
+                        self.source_slice(span, &tab).expect("highlighted_source_2")
+                    };
+
+                    // Write line number, border, and underline
+                    Gutter::new(line_index.number(), gutter_padding).emit(writer, config)?;
+                    BorderLeft::new().emit(writer, config)?;
+                    UnderlineLeft::new(*mark_style).emit(writer, config)?;
+
+                    // Write highlighted source
+                    writer.set_color(label_style)?;
+                    write!(writer, " {}", highlighted_source.trim_end())?;
+                    writer.reset()?;
+                    NewLine::new().emit(writer, config)?;
+                }
+
+                // Write last highlighted line
+                //
+                // ```text
+                // 8 │ │     _ _ => num
+                //   │ ╰──────────────^ `case` clauses have incompatible types
+                // ```
+                let highlighted_source = {
+                    let span = Span::new(end_line_span.start(), label.span.end());
+                    self.source_slice(span, &tab).expect("highlighted_source_3")
+                };
+                let suffix_source = {
+                    let span = Span::new(label.span.end(), end_line_span.end());
+                    self.source_slice(span, &tab).expect("suffix_source")
                 };
 
                 // Write line number, border, and underline
-                Gutter::new(line_index.number(), gutter_padding).emit(writer, config)?;
+                Gutter::new(end.line.number(), gutter_padding).emit(writer, config)?;
                 BorderLeft::new().emit(writer, config)?;
-                UnderlineLeft::new(self.mark_style).emit(writer, config)?;
+                UnderlineLeft::new(*mark_style).emit(writer, config)?;
 
-                // Write highlighted source
+                // Write line source
                 writer.set_color(label_style)?;
-                write!(writer, " {}", highlighted_source.trim_end())?;
+                write!(writer, " {}", highlighted_source)?;
                 writer.reset()?;
+                write!(writer, "{}", suffix_source.trim_end())?;
                 NewLine::new().emit(writer, config)?;
-            }
 
-            // Write last highlighted line
-            //
-            // ```text
-            // 8 │ │     _ _ => num
-            //   │ ╰──────────────^ `case` clauses have incompatible types
-            // ```
-
-            let highlighted_source = {
-                let span = Span::new(end_line_span.start(), self.span.end());
-                self.source_slice(span, &tab).expect("highlighted_source_3")
+                // Write border, underline, and label
+                Gutter::new(None, gutter_padding).emit(writer, config)?;
+                BorderLeft::new().emit(writer, config)?;
+                UnderlineBottom::new(*mark_style, &highlighted_source, &label.message)
+                    .emit(writer, config)?;
+                NewLine::new().emit(writer, config)?;
             };
-            let suffix_source = {
-                let span = Span::new(self.span.end(), end_line_span.end());
-                self.source_slice(span, &tab).expect("suffix_source")
-            };
-
-            // Write line number, border, and underline
-            Gutter::new(end.line.number(), gutter_padding).emit(writer, config)?;
-            BorderLeft::new().emit(writer, config)?;
-            UnderlineLeft::new(self.mark_style).emit(writer, config)?;
-
-            // Write line source
-            writer.set_color(label_style)?;
-            write!(writer, " {}", highlighted_source)?;
-            writer.reset()?;
-            write!(writer, "{}", suffix_source.trim_end())?;
-            NewLine::new().emit(writer, config)?;
-
-            // Write border, underline, and label
-            Gutter::new(None, gutter_padding).emit(writer, config)?;
-            BorderLeft::new().emit(writer, config)?;
-            UnderlineBottom::new(self.mark_style, &highlighted_source, self.message)
-                .emit(writer, config)?;
-            NewLine::new().emit(writer, config)?;
-        };
+        }
 
         // Write final border
         Gutter::new(None, gutter_padding).emit(writer, config)?;

--- a/codespan-reporting/tests/snapshots/empty_spans__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/empty_spans__rich_color.snap
@@ -1,8 +1,8 @@
 ---
-created: "2019-06-23T06:38:18.076818Z"
-creator: insta@0.8.1
+created: "2019-08-28T14:41:01.270444Z"
+creator: insta@0.10.1
 source: codespan-reporting/tests/term.rs
-expression: result
+expression: TEST_DATA.emit_color(&config)
 ---
 {fg:Green bold bright}note{bold bright}: middle{/}
 

--- a/codespan-reporting/tests/snapshots/empty_spans__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/empty_spans__rich_no_color.snap
@@ -1,8 +1,8 @@
 ---
-created: "2019-06-23T06:38:18.077231Z"
-creator: insta@0.8.1
+created: "2019-08-28T14:41:01.271832Z"
+creator: insta@0.10.1
 source: codespan-reporting/tests/term.rs
-expression: result
+expression: TEST_DATA.emit_no_color(&config)
 ---
 note: middle
 

--- a/codespan-reporting/tests/snapshots/fizz_buzz__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/fizz_buzz__rich_color.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-08-25T12:17:21.888579Z"
+created: "2019-08-28T14:48:32.919789Z"
 creator: insta@0.10.1
 source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_color(&config)
@@ -10,7 +10,7 @@ expression: TEST_DATA.emit_color(&config)
    {fg:Blue}│{/}
  {fg:Blue}8{/} {fg:Blue}│{/}     _ _ => {fg:Red}num{/}
    {fg:Blue}│{/}            {fg:Red}^^^ expected `String`, found `Nat`{/}
-   {fg:Blue}│{/}
+   {fg:Blue}·{/}
  {fg:Blue}4{/} {fg:Blue}│{/}   fizz₁ num = {fg:Blue}case (mod num 5) (mod num 3) of{/}
    {fg:Blue}│{/} {fg:Blue}╭─────────────'{/}
  {fg:Blue}5{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}     0 0 => "FizzBuzz"{/}
@@ -18,7 +18,7 @@ expression: TEST_DATA.emit_color(&config)
  {fg:Blue}7{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}     _ 0 => "Buzz"{/}
  {fg:Blue}8{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}     _ _ => num{/}
    {fg:Blue}│{/} {fg:Blue}╰──────────────' `case` clauses have incompatible types{/}
-   {fg:Blue}│{/}
+   {fg:Blue}·{/}
  {fg:Blue}3{/} {fg:Blue}│{/} fizz₁ : Nat → {fg:Blue}String{/}
    {fg:Blue}│{/}               {fg:Blue}------ expected type `String` found here{/}
    {fg:Blue}│{/}
@@ -31,20 +31,20 @@ expression: TEST_DATA.emit_color(&config)
     {fg:Blue}│{/}
  {fg:Blue}15{/} {fg:Blue}│{/}         _ _ => {fg:Red}num{/}
     {fg:Blue}│{/}                {fg:Red}^^^ expected `String`, found `Nat`{/}
-    {fg:Blue}│{/}
+    {fg:Blue}·{/}
  {fg:Blue}11{/} {fg:Blue}│{/} {fg:Blue}╭{/}     {fg:Blue}case (mod num 5) (mod num 3) of{/}
  {fg:Blue}12{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}         0 0 => "FizzBuzz"{/}
  {fg:Blue}13{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}         0 _ => "Fizz"{/}
  {fg:Blue}14{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}         _ 0 => "Buzz"{/}
  {fg:Blue}15{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}         _ _ => num{/}
     {fg:Blue}│{/} {fg:Blue}╰──────────────────' `case` clauses have incompatible types{/}
-    {fg:Blue}│{/}
+    {fg:Blue}·{/}
  {fg:Blue}12{/} {fg:Blue}│{/}         0 0 => {fg:Blue}"FizzBuzz"{/}
     {fg:Blue}│{/}                {fg:Blue}---------- this is found to be of type `String`{/}
-    {fg:Blue}│{/}
+    {fg:Blue}·{/}
  {fg:Blue}13{/} {fg:Blue}│{/}         0 _ => {fg:Blue}"Fizz"{/}
     {fg:Blue}│{/}                {fg:Blue}------ this is found to be of type `String`{/}
-    {fg:Blue}│{/}
+    {fg:Blue}·{/}
  {fg:Blue}14{/} {fg:Blue}│{/}         _ 0 => {fg:Blue}"Buzz"{/}
     {fg:Blue}│{/}                {fg:Blue}------ this is found to be of type `String`{/}
     {fg:Blue}│{/}

--- a/codespan-reporting/tests/snapshots/fizz_buzz__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/fizz_buzz__rich_color.snap
@@ -1,20 +1,15 @@
 ---
-created: "2019-06-23T12:32:12.586540Z"
-creator: insta@0.8.1
+created: "2019-08-25T12:17:21.888579Z"
+creator: insta@0.10.1
 source: codespan-reporting/tests/term.rs
-expression: result
+expression: TEST_DATA.emit_color(&config)
 ---
 {fg:Red bold bright}error[E0308]{bold bright}: `case` clauses have incompatible types{/}
 
-   {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:8:12 {fg:Blue}───{/}
+   {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:3:15 {fg:Blue}───{/}
    {fg:Blue}│{/}
  {fg:Blue}8{/} {fg:Blue}│{/}     _ _ => {fg:Red}num{/}
    {fg:Blue}│{/}            {fg:Red}^^^ expected `String`, found `Nat`{/}
-   {fg:Blue}│{/}
-   {fg:Blue}={/} expected type `String`
-        found type `Nat`
-
-   {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:4:13 {fg:Blue}───{/}
    {fg:Blue}│{/}
  {fg:Blue}4{/} {fg:Blue}│{/}   fizz₁ num = {fg:Blue}case (mod num 5) (mod num 3) of{/}
    {fg:Blue}│{/} {fg:Blue}╭─────────────'{/}
@@ -24,24 +19,18 @@ expression: result
  {fg:Blue}8{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}     _ _ => num{/}
    {fg:Blue}│{/} {fg:Blue}╰──────────────' `case` clauses have incompatible types{/}
    {fg:Blue}│{/}
-
-   {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:3:15 {fg:Blue}───{/}
-   {fg:Blue}│{/}
  {fg:Blue}3{/} {fg:Blue}│{/} fizz₁ : Nat → {fg:Blue}String{/}
    {fg:Blue}│{/}               {fg:Blue}------ expected type `String` found here{/}
    {fg:Blue}│{/}
+   {fg:Blue}={/} expected type `String`
+        found type `Nat`
 
 {fg:Red bold bright}error[E0308]{bold bright}: `case` clauses have incompatible types{/}
 
-    {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:15:16 {fg:Blue}───{/}
+    {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:11:5 {fg:Blue}───{/}
     {fg:Blue}│{/}
  {fg:Blue}15{/} {fg:Blue}│{/}         _ _ => {fg:Red}num{/}
     {fg:Blue}│{/}                {fg:Red}^^^ expected `String`, found `Nat`{/}
-    {fg:Blue}│{/}
-    {fg:Blue}={/} expected type `String`
-         found type `Nat`
-
-    {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:11:5 {fg:Blue}───{/}
     {fg:Blue}│{/}
  {fg:Blue}11{/} {fg:Blue}│{/} {fg:Blue}╭{/}     {fg:Blue}case (mod num 5) (mod num 3) of{/}
  {fg:Blue}12{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}         0 0 => "FizzBuzz"{/}
@@ -50,23 +39,16 @@ expression: result
  {fg:Blue}15{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}         _ _ => num{/}
     {fg:Blue}│{/} {fg:Blue}╰──────────────────' `case` clauses have incompatible types{/}
     {fg:Blue}│{/}
-
-    {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:12:16 {fg:Blue}───{/}
-    {fg:Blue}│{/}
  {fg:Blue}12{/} {fg:Blue}│{/}         0 0 => {fg:Blue}"FizzBuzz"{/}
     {fg:Blue}│{/}                {fg:Blue}---------- this is found to be of type `String`{/}
-    {fg:Blue}│{/}
-
-    {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:13:16 {fg:Blue}───{/}
     {fg:Blue}│{/}
  {fg:Blue}13{/} {fg:Blue}│{/}         0 _ => {fg:Blue}"Fizz"{/}
     {fg:Blue}│{/}                {fg:Blue}------ this is found to be of type `String`{/}
     {fg:Blue}│{/}
-
-    {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:14:16 {fg:Blue}───{/}
-    {fg:Blue}│{/}
  {fg:Blue}14{/} {fg:Blue}│{/}         _ 0 => {fg:Blue}"Buzz"{/}
     {fg:Blue}│{/}                {fg:Blue}------ this is found to be of type `String`{/}
     {fg:Blue}│{/}
+    {fg:Blue}={/} expected type `String`
+         found type `Nat`
 
 

--- a/codespan-reporting/tests/snapshots/fizz_buzz__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/fizz_buzz__rich_no_color.snap
@@ -1,20 +1,15 @@
 ---
-created: "2019-06-23T12:32:12.586445Z"
-creator: insta@0.8.1
+created: "2019-08-25T12:17:21.888514Z"
+creator: insta@0.10.1
 source: codespan-reporting/tests/term.rs
-expression: result
+expression: TEST_DATA.emit_no_color(&config)
 ---
 error[E0308]: `case` clauses have incompatible types
 
-   ┌── FizzBuzz.fun:8:12 ───
+   ┌── FizzBuzz.fun:3:15 ───
    │
  8 │     _ _ => num
    │            ^^^ expected `String`, found `Nat`
-   │
-   = expected type `String`
-        found type `Nat`
-
-   ┌── FizzBuzz.fun:4:13 ───
    │
  4 │   fizz₁ num = case (mod num 5) (mod num 3) of
    │ ╭─────────────'
@@ -24,24 +19,18 @@ error[E0308]: `case` clauses have incompatible types
  8 │ │     _ _ => num
    │ ╰──────────────' `case` clauses have incompatible types
    │
-
-   ┌── FizzBuzz.fun:3:15 ───
-   │
  3 │ fizz₁ : Nat → String
    │               ------ expected type `String` found here
    │
+   = expected type `String`
+        found type `Nat`
 
 error[E0308]: `case` clauses have incompatible types
 
-    ┌── FizzBuzz.fun:15:16 ───
+    ┌── FizzBuzz.fun:11:5 ───
     │
  15 │         _ _ => num
     │                ^^^ expected `String`, found `Nat`
-    │
-    = expected type `String`
-         found type `Nat`
-
-    ┌── FizzBuzz.fun:11:5 ───
     │
  11 │ ╭     case (mod num 5) (mod num 3) of
  12 │ │         0 0 => "FizzBuzz"
@@ -50,23 +39,16 @@ error[E0308]: `case` clauses have incompatible types
  15 │ │         _ _ => num
     │ ╰──────────────────' `case` clauses have incompatible types
     │
-
-    ┌── FizzBuzz.fun:12:16 ───
-    │
  12 │         0 0 => "FizzBuzz"
     │                ---------- this is found to be of type `String`
-    │
-
-    ┌── FizzBuzz.fun:13:16 ───
     │
  13 │         0 _ => "Fizz"
     │                ------ this is found to be of type `String`
     │
-
-    ┌── FizzBuzz.fun:14:16 ───
-    │
  14 │         _ 0 => "Buzz"
     │                ------ this is found to be of type `String`
     │
+    = expected type `String`
+         found type `Nat`
 
 

--- a/codespan-reporting/tests/snapshots/fizz_buzz__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/fizz_buzz__rich_no_color.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-08-25T12:17:21.888514Z"
+created: "2019-08-28T14:48:32.919737Z"
 creator: insta@0.10.1
 source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_no_color(&config)
@@ -10,7 +10,7 @@ error[E0308]: `case` clauses have incompatible types
    │
  8 │     _ _ => num
    │            ^^^ expected `String`, found `Nat`
-   │
+   ·
  4 │   fizz₁ num = case (mod num 5) (mod num 3) of
    │ ╭─────────────'
  5 │ │     0 0 => "FizzBuzz"
@@ -18,7 +18,7 @@ error[E0308]: `case` clauses have incompatible types
  7 │ │     _ 0 => "Buzz"
  8 │ │     _ _ => num
    │ ╰──────────────' `case` clauses have incompatible types
-   │
+   ·
  3 │ fizz₁ : Nat → String
    │               ------ expected type `String` found here
    │
@@ -31,20 +31,20 @@ error[E0308]: `case` clauses have incompatible types
     │
  15 │         _ _ => num
     │                ^^^ expected `String`, found `Nat`
-    │
+    ·
  11 │ ╭     case (mod num 5) (mod num 3) of
  12 │ │         0 0 => "FizzBuzz"
  13 │ │         0 _ => "Fizz"
  14 │ │         _ 0 => "Buzz"
  15 │ │         _ _ => num
     │ ╰──────────────────' `case` clauses have incompatible types
-    │
+    ·
  12 │         0 0 => "FizzBuzz"
     │                ---------- this is found to be of type `String`
-    │
+    ·
  13 │         0 _ => "Fizz"
     │                ------ this is found to be of type `String`
-    │
+    ·
  14 │         _ 0 => "Buzz"
     │                ------ this is found to be of type `String`
     │

--- a/codespan-reporting/tests/snapshots/multifile__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/multifile__rich_color.snap
@@ -1,8 +1,8 @@
 ---
-created: "2019-06-23T06:38:18.077448Z"
-creator: insta@0.8.1
+created: "2019-08-28T14:41:01.270642Z"
+creator: insta@0.10.1
 source: codespan-reporting/tests/term.rs
-expression: result
+expression: TEST_DATA.emit_color(&config)
 ---
 {fg:Red bold bright}error{bold bright}: unknown builtin: `NATRAL`{/}
 

--- a/codespan-reporting/tests/snapshots/multifile__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/multifile__rich_no_color.snap
@@ -1,8 +1,8 @@
 ---
-created: "2019-06-23T06:38:18.076764Z"
-creator: insta@0.8.1
+created: "2019-08-28T14:41:01.270459Z"
+creator: insta@0.10.1
 source: codespan-reporting/tests/term.rs
-expression: result
+expression: TEST_DATA.emit_no_color(&config)
 ---
 error: unknown builtin: `NATRAL`
 

--- a/codespan-reporting/tests/snapshots/tabbed__tab_width_3_no_color.snap
+++ b/codespan-reporting/tests/snapshots/tabbed__tab_width_3_no_color.snap
@@ -1,8 +1,8 @@
 ---
-created: "2019-06-23T06:38:18.080827Z"
-creator: insta@0.8.1
+created: "2019-08-28T14:41:01.276332Z"
+creator: insta@0.10.1
 source: codespan-reporting/tests/term.rs
-expression: result
+expression: TEST_DATA.emit_no_color(&config)
 ---
 warning: unknown weapon `DogJaw`
 

--- a/codespan-reporting/tests/snapshots/tabbed__tab_width_6_no_color.snap
+++ b/codespan-reporting/tests/snapshots/tabbed__tab_width_6_no_color.snap
@@ -1,8 +1,8 @@
 ---
-created: "2019-06-23T06:38:18.080991Z"
-creator: insta@0.8.1
+created: "2019-08-28T14:41:01.277215Z"
+creator: insta@0.10.1
 source: codespan-reporting/tests/term.rs
-expression: result
+expression: TEST_DATA.emit_no_color(&config)
 ---
 warning: unknown weapon `DogJaw`
 

--- a/codespan-reporting/tests/snapshots/tabbed__tab_width_default_no_color.snap
+++ b/codespan-reporting/tests/snapshots/tabbed__tab_width_default_no_color.snap
@@ -1,8 +1,8 @@
 ---
-created: "2019-06-23T06:38:18.143907Z"
-creator: insta@0.8.1
+created: "2019-08-28T14:41:01.350391Z"
+creator: insta@0.10.1
 source: codespan-reporting/tests/term.rs
-expression: result
+expression: TEST_DATA.emit_no_color(&config)
 ---
 warning: unknown weapon `DogJaw`
 


### PR DESCRIPTION
This is a step towards #100. Instead of printing out individual snippets for each labelled span, we group them together on a per-file basis.