### PR TITLE
Fix gutter misalignments

### DIFF
--- a/codespan/src/index.rs
+++ b/codespan/src/index.rs
@@ -53,7 +53,7 @@ impl fmt::Debug for LineIndex {
 
 impl fmt::Display for LineIndex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        self.0.fmt(f)
     }
 }
 
@@ -73,7 +73,7 @@ impl fmt::Debug for LineNumber {
 
 impl fmt::Display for LineNumber {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        self.0.fmt(f)
     }
 }
 
@@ -99,7 +99,7 @@ impl fmt::Debug for LineOffset {
 
 impl fmt::Display for LineOffset {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        self.0.fmt(f)
     }
 }
 
@@ -144,7 +144,7 @@ impl fmt::Debug for ColumnIndex {
 
 impl fmt::Display for ColumnIndex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        self.0.fmt(f)
     }
 }
 
@@ -164,7 +164,7 @@ impl fmt::Debug for ColumnNumber {
 
 impl fmt::Display for ColumnNumber {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        self.0.fmt(f)
     }
 }
 
@@ -223,7 +223,7 @@ impl fmt::Debug for ByteIndex {
 
 impl fmt::Display for ByteIndex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        self.0.fmt(f)
     }
 }
 
@@ -285,7 +285,7 @@ impl fmt::Debug for ByteOffset {
 
 impl fmt::Display for ByteOffset {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        self.0.fmt(f)
     }
 }
 


### PR DESCRIPTION
Fixes #130.

This code attempts to print a value of type codespan::LineNumber with [padding](https://doc.rust-lang.org/std/fmt/struct.Formatter.html#method.width) and [alignment](https://doc.rust-lang.org/std/fmt/struct.Formatter.html#method.align):

https://github.com/brendanzab/codespan/blob/6cec7d52c81c78a773bfec6a92a17de534c11fff/codespan-reporting/src/term/views/source_snippet/gutter.rs#L34-L39

But the Display impl for LineNumber just ignores the requested padding and alignment:

https://github.com/brendanzab/codespan/blob/6cec7d52c81c78a773bfec6a92a17de534c11fff/codespan/src/index.rs#L74-L78

Repro:

```rust
use codespan::Files;
use codespan_reporting::diagnostic::{Diagnostic, Label};
use codespan_reporting::term::emit;
use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};

fn main() {
    let mut files = Files::new();
    let content = "\n\n\n\n\n\naaaaaaaaaa\n\nbbbbbbbbbb\ncccccccccc\n";
    let file = files.add("path/to", content);
    let diagnostic = Diagnostic::new_error("it failed", Label::new(file, 8..34, "error"));
    let writer = StandardStream::stderr(ColorChoice::Auto);
    let config = codespan_reporting::term::Config::default();
    emit(&mut writer.lock(), &config, &files, &diagnostic).unwrap();
}
```

Before:

```console
error: it failed

    ┌── path/to:7:3 ───
    │
 7 │   aaaaaaaaaa
    │ ╭───^
 8 │ │ 
 9 │ │ bbbbbbbbbb
 10 │ │ cccccccccc
    │ ╰─────^ error
    │
```

After:

```console
error: it failed

    ┌── path/to:7:3 ───
    │
  7 │   aaaaaaaaaa
    │ ╭───^
  8 │ │ 
  9 │ │ bbbbbbbbbb
 10 │ │ cccccccccc
    │ ╰─────^ error
    │
```