### PR TITLE
Make Span::initial() a const fn

### DIFF
--- a/codespan/src/span.rs
+++ b/codespan/src/span.rs
@@ -25,8 +25,11 @@ impl Span {
     }
 
     /// Gives an empty span at the start of a source.
-    pub fn initial() -> Span {
-        Span::new(0, 0)
+    pub const fn initial() -> Span {
+        Span {
+            start: ByteIndex(0),
+            end: ByteIndex(0),
+        }
     }
 
     /// Measure the span of a string.


### PR DESCRIPTION
In Arret nearly every intermediate data structure contains a `Span` so our generated code can be mapped back to source location. However, they're rarely used until we need to report a diagnostic or generate debugging information.

This led to a common pattern in unit tests where we use a dummy span to test intermediate transformations where we aren't starting from actual Arret source. This used to be a `const` called `EMPTY_SPAN` which can be used to build other `const` data structures used for testing.

In etaoins/arret#160 we needed to switch to an `empty_span()` function because there is no longer a `const` constructor for `Span`.

We can't make `Span::new` `const` yet because const functions are not powerful enough. However, `Span::initial` is perfect for this use case.