### PR TITLE
Make `FileId` non-zero

### DIFF
--- a/codespan/src/file.rs
+++ b/codespan/src/file.rs
@@ -67,8 +67,15 @@ impl fmt::Display for SpanOutOfBoundsError {
 /// A handle that points to a file in the database.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "memory_usage", derive(heapsize_derive::HeapSizeOf))]
 pub struct FileId(NonZeroU32);
+
+// `HeapSizeOf` isn't implemented for `NonZeroU32` and we can't add it due to trait orphan rules
+#[cfg(feature = "memory_usage")]
+impl heapsize::HeapSizeOf for FileId {
+    fn heap_size_of_children(&self) -> usize {
+        0
+    }
+}
 
 impl FileId {
     /// Offset of our `FileId`'s numeric value to an index on `Files::files`.


### PR DESCRIPTION
When porting from `codespan` 0.3 Arret I needed to track the `FileId` separately from the `Span` now that the file isn't implied in the span itself. Having a simple struct like this works for 90% of the cases:

```rust
struct Span {
  file_id: codespan::FileId,
  codespan_span: codespan::Span,
}
```

However, this requires that every time we parse any source we require a `FileId` which requires a `codespan::Files` to create. This is overkill in a couple of cases:

1. Unit tests that just need to parse simple Arret strings as a shorthand for building our AST

2. Syntax highlighting in the REPL

The compromise in etaoins/arret#160 is to use `Option<FileId>`. I'm not 100% happy with that as the ultimate solution but it was the easiest path to take during porting. However, this makes the size of the above struct 13 bytes which will typically be rounded up to 16 bytes for alignment and padding.

We can use `std::num::NonZeroU32` instead and offset all of our indexes by 1. This allows the Rust compiler to use 0 to represent the `None` case and bring the size down to 12 bytes. Because the struct only needs an alignment of 4 bytes this is more likely to stay as 12 bytes in most contexts.

A nicer solution would be if Rust had e.g. `NonMaxU32` but it appears the Rust team instead wants to use const generics so arbitrary niche values can be specified.