### PR TITLE
Have `Span` take self by value

### DIFF
--- a/codespan/src/span.rs
+++ b/codespan/src/span.rs
@@ -66,7 +66,7 @@ impl Span {
     ///
     /// assert_eq!(span.start(), ByteIndex::from(0));
     /// ```
-    pub fn start(&self) -> ByteIndex {
+    pub fn start(self) -> ByteIndex {
         self.start
     }
 
@@ -79,7 +79,7 @@ impl Span {
     ///
     /// assert_eq!(span.end(), ByteIndex::from(4));
     /// ```
-    pub fn end(&self) -> ByteIndex {
+    pub fn end(self) -> ByteIndex {
         self.end
     }
 }


### PR DESCRIPTION
This was caught by Clippy. `Span` is an 8 byte copy type so it makes sense to take it by value instead of reference. This is consistent with what `merge` was already doing.