### PR TITLE
Create Files trait

### DIFF
--- a/codespan-lsp/Cargo.toml
+++ b/codespan-lsp/Cargo.toml
@@ -11,6 +11,5 @@ edition = "2018"
 
 [dependencies]
 codespan = { version = "0.8.0", path = "../codespan" } # CODESPAN
-codespan-reporting = { version = "0.8.0", path = "../codespan-reporting/" } # CODESPAN
 lsp-types = "0.70"
 url = "2"

--- a/codespan-reporting/src/diagnostic.rs
+++ b/codespan-reporting/src/diagnostic.rs
@@ -1,9 +1,9 @@
 //! Diagnostic data structures.
 
-use codespan::{FileId, Span};
 #[cfg(feature = "serialization")]
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
+use std::ops::Range;
 
 /// A severity level for diagnostic messages.
 ///
@@ -54,22 +54,26 @@ impl PartialOrd for Severity {
 /// A label describing an underlined region of code associated with a diagnostic.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
-pub struct Label {
+pub struct Label<FileId> {
     /// The file that we are labelling.
     pub file_id: FileId,
-    /// The span we are going to include in the final snippet.
-    pub span: Span,
+    /// The range we are going to include in the final snippet.
+    pub range: Range<usize>,
     /// A message to provide some additional information for the underlined
     /// code. These should not include line breaks.
     pub message: String,
 }
 
-impl Label {
+impl<FileId> Label<FileId> {
     /// Create a new label.
-    pub fn new(file_id: FileId, span: impl Into<Span>, message: impl Into<String>) -> Label {
+    pub fn new(
+        file_id: FileId,
+        range: impl Into<Range<usize>>,
+        message: impl Into<String>,
+    ) -> Label<FileId> {
         Label {
             file_id,
-            span: span.into(),
+            range: range.into(),
             message: message.into(),
         }
     }
@@ -77,9 +81,9 @@ impl Label {
 
 /// Represents a diagnostic message that can provide information like errors and
 /// warnings to the user.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
-pub struct Diagnostic {
+pub struct Diagnostic<FileId> {
     /// The overall severity of the diagnostic
     pub severity: Severity,
     /// An optional code that identifies this diagnostic.
@@ -91,17 +95,21 @@ pub struct Diagnostic {
     /// `primary_label`.
     pub message: String,
     /// A label that describes the primary cause of this diagnostic.
-    pub primary_label: Label,
+    pub primary_label: Label<FileId>,
     /// Notes that are associated with the primary cause of the diagnostic.
     /// These can include line breaks for improved formatting.
     pub notes: Vec<String>,
     /// Secondary labels that provide additional context for the diagnostic.
-    pub secondary_labels: Vec<Label>,
+    pub secondary_labels: Vec<Label<FileId>>,
 }
 
-impl Diagnostic {
+impl<FileId> Diagnostic<FileId> {
     /// Create a new diagnostic.
-    pub fn new(severity: Severity, message: impl Into<String>, primary_label: Label) -> Diagnostic {
+    pub fn new(
+        severity: Severity,
+        message: impl Into<String>,
+        primary_label: Label<FileId>,
+    ) -> Diagnostic<FileId> {
         Diagnostic {
             severity,
             code: None,
@@ -113,45 +121,148 @@ impl Diagnostic {
     }
 
     /// Create a new diagnostic with a severity of `Severity::Bug`.
-    pub fn new_bug(message: impl Into<String>, primary_label: Label) -> Diagnostic {
+    pub fn new_bug(message: impl Into<String>, primary_label: Label<FileId>) -> Diagnostic<FileId> {
         Diagnostic::new(Severity::Bug, message, primary_label)
     }
 
     /// Create a new diagnostic with a severity of `Severity::Error`.
-    pub fn new_error(message: impl Into<String>, primary_label: Label) -> Diagnostic {
+    pub fn new_error(
+        message: impl Into<String>,
+        primary_label: Label<FileId>,
+    ) -> Diagnostic<FileId> {
         Diagnostic::new(Severity::Error, message, primary_label)
     }
 
     /// Create a new diagnostic with a severity of `Severity::Warning`.
-    pub fn new_warning(message: impl Into<String>, primary_label: Label) -> Diagnostic {
+    pub fn new_warning(
+        message: impl Into<String>,
+        primary_label: Label<FileId>,
+    ) -> Diagnostic<FileId> {
         Diagnostic::new(Severity::Warning, message, primary_label)
     }
 
     /// Create a new diagnostic with a severity of `Severity::Note`.
-    pub fn new_note(message: impl Into<String>, primary_label: Label) -> Diagnostic {
+    pub fn new_note(
+        message: impl Into<String>,
+        primary_label: Label<FileId>,
+    ) -> Diagnostic<FileId> {
         Diagnostic::new(Severity::Note, message, primary_label)
     }
 
     /// Create a new diagnostic with a severity of `Severity::Help`.
-    pub fn new_help(message: impl Into<String>, primary_label: Label) -> Diagnostic {
+    pub fn new_help(
+        message: impl Into<String>,
+        primary_label: Label<FileId>,
+    ) -> Diagnostic<FileId> {
         Diagnostic::new(Severity::Help, message, primary_label)
     }
 
     /// Add an error code to the diagnostic.
-    pub fn with_code(mut self, code: impl Into<String>) -> Diagnostic {
+    pub fn with_code(mut self, code: impl Into<String>) -> Diagnostic<FileId> {
         self.code = Some(code.into());
         self
     }
 
     /// Add some notes to the diagnostic.
-    pub fn with_notes(mut self, notes: Vec<String>) -> Diagnostic {
+    pub fn with_notes(mut self, notes: Vec<String>) -> Diagnostic<FileId> {
         self.notes = notes;
         self
     }
 
     /// Add some secondary labels to the diagnostic.
-    pub fn with_secondary_labels(mut self, labels: impl IntoIterator<Item = Label>) -> Diagnostic {
+    pub fn with_secondary_labels(
+        mut self,
+        labels: impl IntoIterator<Item = Label<FileId>>,
+    ) -> Diagnostic<FileId> {
         self.secondary_labels.extend(labels);
         self
+    }
+}
+
+/// A location in a source file.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Location {
+    /// The line index in the source file.
+    pub line: usize,
+    /// The column index in the source file.
+    pub column: usize,
+}
+
+/// A line within a source file.
+pub struct Line<Source> {
+    /// The starting byte index of the line.
+    pub start: usize,
+    /// The source of the line.
+    pub source: Source,
+}
+
+impl<Source> Line<Source>
+where
+    Source: AsRef<str>,
+{
+    pub fn column_index(&self, byte_index: usize) -> Option<usize> {
+        match byte_index.checked_sub(self.start) {
+            None => Some(0),
+            Some(relative_index) => {
+                let source = self.source.as_ref().get(..relative_index)?;
+                Some(source.chars().count())
+            },
+        }
+    }
+}
+
+/// Files that can be used for pretty printing.
+pub trait Files {
+    type FileId: Copy + PartialEq + PartialOrd + Eq + Ord + std::hash::Hash;
+    type Origin: std::fmt::Display;
+    type LineSource: AsRef<str>;
+
+    /// The origin of a file.
+    fn origin(&self, id: Self::FileId) -> Option<Self::Origin>;
+
+    /// The line at the given index.
+    fn line(&self, id: Self::FileId, line_index: usize) -> Option<Line<Self::LineSource>>;
+
+    /// The index of the line at the given byte index.
+    fn line_index(&self, id: Self::FileId, byte_index: usize) -> Option<usize>;
+
+    /// The location of the given byte index.
+    fn location(&self, id: Self::FileId, byte_index: usize) -> Option<Location> {
+        let line_index = self.line_index(id, byte_index)?;
+        let column_index = self.line(id, line_index)?.column_index(byte_index)?;
+
+        Some(Location {
+            line: line_index,
+            column: column_index,
+        })
+    }
+}
+
+impl<Source> Files for codespan::Files<Source>
+where
+    Source: AsRef<str>,
+{
+    type FileId = codespan::FileId;
+    type Origin = String;
+    type LineSource = String;
+
+    fn origin(&self, id: codespan::FileId) -> Option<String> {
+        use std::path::PathBuf;
+
+        Some(PathBuf::from(self.name(id)).display().to_string())
+    }
+
+    fn line_index(&self, id: Self::FileId, byte_index: usize) -> Option<usize> {
+        Some(self.line_index(id, byte_index as u32).to_usize())
+    }
+
+    fn line(&self, id: codespan::FileId, line_index: usize) -> Option<Line<String>> {
+        let span = self.line_span(id, line_index as u32).ok()?;
+        let source = self.source_slice(id, span).ok()?;
+
+        Some(Line {
+            start: span.start().to_usize(),
+            source: source.to_owned(),
+        })
     }
 }

--- a/codespan-reporting/src/term.rs
+++ b/codespan-reporting/src/term.rs
@@ -1,11 +1,10 @@
 //! Terminal back-end for emitting diagnostics.
 
-use codespan::Files;
 use std::io;
 use std::str::FromStr;
 use termcolor::{ColorChoice, WriteColor};
 
-use crate::diagnostic::Diagnostic;
+use crate::diagnostic::{Diagnostic, Files};
 
 mod config;
 mod views;
@@ -15,11 +14,11 @@ pub use termcolor;
 pub use self::config::{Chars, Config, DisplayStyle, Styles};
 
 /// Emit a diagnostic using the given writer, context, config, and files.
-pub fn emit<Source: AsRef<str>>(
+pub fn emit<F: Files>(
     writer: &mut (impl WriteColor + ?Sized),
     config: &Config,
-    files: &Files<Source>,
-    diagnostic: &Diagnostic,
+    files: &F,
+    diagnostic: &Diagnostic<F::FileId>,
 ) -> io::Result<()> {
     use self::views::{RichDiagnostic, ShortDiagnostic};
 
@@ -98,14 +97,14 @@ mod tests {
 
     #[test]
     fn unsized_emit() {
-        let mut files = Files::new();
+        let mut files = codespan::Files::new();
 
         let id = files.add("test", "");
         emit(
             &mut termcolor::NoColor::new(Vec::<u8>::new()) as &mut dyn WriteColor,
             &Config::default(),
             &files,
-            &Diagnostic::new_bug("", Label::new(id, codespan::Span::default(), "")),
+            &Diagnostic::new_bug("", Label::new(id, 0..0, "")),
         )
         .unwrap();
     }

--- a/codespan-reporting/src/term/views/diagnostic.rs
+++ b/codespan-reporting/src/term/views/diagnostic.rs
@@ -1,25 +1,27 @@
-use codespan::Files;
 use std::io;
 use termcolor::WriteColor;
 
-use crate::diagnostic::Diagnostic;
+use crate::diagnostic::{Diagnostic, Files};
 use crate::term::Config;
 
 use super::{Header, Locus, NewLine, SourceSnippet};
 
 /// Output a richly formatted diagnostic, with source code previews.
-pub struct RichDiagnostic<'a> {
-    diagnostic: &'a Diagnostic,
+pub struct RichDiagnostic<'a, FileId> {
+    diagnostic: &'a Diagnostic<FileId>,
 }
 
-impl<'a> RichDiagnostic<'a> {
-    pub fn new(diagnostic: &'a Diagnostic) -> Self {
+impl<'a, FileId> RichDiagnostic<'a, FileId>
+where
+    FileId: Copy + PartialEq + PartialOrd + Eq + Ord + std::hash::Hash,
+{
+    pub fn new(diagnostic: &'a Diagnostic<FileId>) -> RichDiagnostic<'a, FileId> {
         RichDiagnostic { diagnostic }
     }
 
     pub fn emit(
         &self,
-        files: &'a Files<impl AsRef<str>>,
+        files: &impl Files<FileId = FileId>,
         writer: &mut (impl WriteColor + ?Sized),
         config: &Config,
     ) -> io::Result<()> {
@@ -67,27 +69,32 @@ impl<'a> RichDiagnostic<'a> {
 }
 
 /// Output a short diagnostic, with a line number, severity, and message.
-pub struct ShortDiagnostic<'a> {
-    diagnostic: &'a Diagnostic,
+pub struct ShortDiagnostic<'a, FileId> {
+    diagnostic: &'a Diagnostic<FileId>,
 }
 
-impl<'a> ShortDiagnostic<'a> {
-    pub fn new(diagnostic: &'a Diagnostic) -> ShortDiagnostic<'a> {
+impl<'a, FileId> ShortDiagnostic<'a, FileId>
+where
+    FileId: Copy + PartialEq + PartialOrd + Eq + Ord + std::hash::Hash,
+{
+    pub fn new(diagnostic: &'a Diagnostic<FileId>) -> ShortDiagnostic<'a, FileId> {
         ShortDiagnostic { diagnostic }
     }
 
     pub fn emit(
         &self,
-        files: &'a Files<impl AsRef<str>>,
+        files: &impl Files<FileId = FileId>,
         writer: &mut (impl WriteColor + ?Sized),
         config: &Config,
     ) -> io::Result<()> {
         let label = &self.diagnostic.primary_label;
+        let origin = files
+            .origin(self.diagnostic.primary_label.file_id)
+            .expect("origin");
         let location = files
-            .location(label.file_id, label.span.start())
+            .location(label.file_id, label.range.start)
             .expect("location");
-        Locus::new(files.name(self.diagnostic.primary_label.file_id), location)
-            .emit(writer, config)?;
+        Locus::new(origin, location).emit(writer, config)?;
         write!(writer, ": ")?;
         Header::new(self.diagnostic).emit(writer, config)?;
 

--- a/codespan-reporting/src/term/views/header.rs
+++ b/codespan-reporting/src/term/views/header.rs
@@ -19,7 +19,7 @@ pub struct Header<'a> {
 }
 
 impl<'a> Header<'a> {
-    pub fn new(diagnostic: &'a Diagnostic) -> Header<'a> {
+    pub fn new<FileId>(diagnostic: &'a Diagnostic<FileId>) -> Header<'a> {
         Header {
             severity: diagnostic.severity,
             code: diagnostic.code.as_ref().map(String::as_str),

--- a/codespan-reporting/src/term/views/locus.rs
+++ b/codespan-reporting/src/term/views/locus.rs
@@ -1,8 +1,7 @@
-use codespan::Location;
-use std::ffi::OsStr;
 use std::io;
 use termcolor::WriteColor;
 
+use crate::diagnostic::Location;
 use crate::term::Config;
 
 /// The 'location focus' of a source code snippet.
@@ -13,17 +12,17 @@ use crate::term::Config;
 /// ```text
 /// test:2:9
 /// ```
-pub struct Locus<'a> {
-    file_name: &'a OsStr,
+pub struct Locus<Origin> {
+    origin: Origin,
     location: Location,
 }
 
-impl<'a> Locus<'a> {
-    pub fn new(file_name: &'a OsStr, location: Location) -> Locus<'a> {
-        Locus {
-            file_name,
-            location,
-        }
+impl<Origin> Locus<Origin>
+where
+    Origin: std::fmt::Display,
+{
+    pub fn new(origin: Origin, location: Location) -> Locus<Origin> {
+        Locus { origin, location }
     }
 
     pub fn emit(
@@ -31,13 +30,12 @@ impl<'a> Locus<'a> {
         writer: &mut (impl WriteColor + ?Sized),
         _config: &Config,
     ) -> io::Result<()> {
-        use std::path::PathBuf;
         write!(
             writer,
-            "{file}:{line}:{column}",
-            file = PathBuf::from(self.file_name).display(),
-            line = self.location.line.number(),
-            column = self.location.column.number(),
+            "{origin}:{line}:{column}",
+            origin = self.origin,
+            line = self.location.line + 1,
+            column = self.location.column + 1,
         )
     }
 }

--- a/codespan-reporting/src/term/views/source_snippet/gutter.rs
+++ b/codespan-reporting/src/term/views/source_snippet/gutter.rs
@@ -1,4 +1,3 @@
-use codespan::LineNumber;
 use std::io;
 use termcolor::WriteColor;
 
@@ -6,21 +5,21 @@ use crate::term::Config;
 
 /// The left-hand gutter of a source line.
 pub struct Gutter {
-    line_number: Option<LineNumber>,
+    line_index: Option<usize>,
     gutter_padding: usize,
 }
 
 impl Gutter {
-    pub fn new(line_number: impl Into<Option<LineNumber>>, gutter_padding: usize) -> Gutter {
+    pub fn new(line_index: impl Into<Option<usize>>, gutter_padding: usize) -> Gutter {
         Gutter {
-            line_number: line_number.into(),
+            line_index: line_index.into(),
             gutter_padding,
         }
     }
 
     pub fn emit(&self, writer: &mut (impl WriteColor + ?Sized), config: &Config) -> io::Result<()> {
         write!(writer, " ")?;
-        match self.line_number {
+        match self.line_index {
             None => {
                 write!(
                     writer,
@@ -29,12 +28,12 @@ impl Gutter {
                     width = self.gutter_padding,
                 )?;
             },
-            Some(line_number) => {
+            Some(line_index) => {
                 writer.set_color(&config.styles.line_number)?;
                 write!(
                     writer,
                     "{line: >width$}",
-                    line = line_number,
+                    line = line_index + 1,
                     width = self.gutter_padding,
                 )?;
                 writer.reset()?;

--- a/codespan-reporting/tests/support/mod.rs
+++ b/codespan-reporting/tests/support/mod.rs
@@ -9,7 +9,7 @@ use self::color_buffer::ColorBuffer;
 
 pub struct TestData {
     pub files: Files<String>,
-    pub diagnostics: Vec<Diagnostic>,
+    pub diagnostics: Vec<Diagnostic<codespan::FileId>>,
 }
 
 impl TestData {

--- a/codespan-reporting/tests/term.rs
+++ b/codespan-reporting/tests/term.rs
@@ -22,7 +22,7 @@ mod empty_spans {
             let mut files = Files::new();
 
             let file_id = files.add("hello", "Hello world!\nBye world!".to_owned());
-            let eof = files.source_span(file_id).end();
+            let eof = files.source_span(file_id).end().to_usize();
 
             let diagnostics = vec![
                 Diagnostic::new_note("middle", Label::new(file_id, 6..6, "middle")),

--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1", optional = true, features = ["derive"]}
-unicode-segmentation = "1.6"
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/codespan/src/file.rs
+++ b/codespan/src/file.rs
@@ -196,6 +196,24 @@ where
         self.get(file_id).line_span(line_index.into())
     }
 
+    /// Get the line index at the given byte in the source file.
+    ///
+    /// ```rust
+    /// use codespan::{Files, LineIndex};
+    ///
+    /// let mut files = Files::new();
+    /// let file_id = files.add("test", "foo\nbar\r\n\nbaz");
+    ///
+    /// assert_eq!(files.line_index(file_id, 0), LineIndex::from(0));
+    /// assert_eq!(files.line_index(file_id, 7), LineIndex::from(1));
+    /// assert_eq!(files.line_index(file_id, 8), LineIndex::from(1));
+    /// assert_eq!(files.line_index(file_id, 9), LineIndex::from(2));
+    /// assert_eq!(files.line_index(file_id, 100), LineIndex::from(3));
+    /// ```
+    pub fn line_index(&self, file_id: FileId, byte_index: impl Into<ByteIndex>) -> LineIndex {
+        self.get(file_id).line_index(byte_index.into())
+    }
+
     /// Get the location at the given byte index in the source file.
     ///
     /// ```rust
@@ -344,41 +362,40 @@ where
         Ok(Span::new(line_start, next_line_start))
     }
 
-    fn location(&self, byte_index: ByteIndex) -> Result<Location, LocationError> {
-        use unicode_segmentation::UnicodeSegmentation;
-
+    fn line_index(&self, byte_index: ByteIndex) -> LineIndex {
         match self.line_starts.binary_search(&byte_index) {
             // Found the start of a line
-            Ok(line) => Ok(Location::new(line as u32, 0)),
-            // Found something in the middle of a line
-            Err(next_line) => {
-                let line_index = LineIndex::from(next_line as u32 - 1);
-                let line_start_index =
-                    self.line_start(line_index)
-                        .map_err(|_| LocationError::OutOfBounds {
-                            given: byte_index,
-                            span: self.source_span(),
-                        })?;
-                let line_src = self
-                    .source
-                    .as_ref()
-                    .get(line_start_index.to_usize()..byte_index.to_usize())
-                    .ok_or_else(|| {
-                        let given = byte_index;
-                        if given >= self.source_span().end() {
-                            let span = self.source_span();
-                            LocationError::OutOfBounds { given, span }
-                        } else {
-                            LocationError::InvalidCharBoundary { given }
-                        }
-                    })?;
-
-                Ok(Location {
-                    line: line_index,
-                    column: ColumnIndex::from(line_src.graphemes(true).count() as u32),
-                })
-            },
+            Ok(line) => LineIndex::from(line as u32),
+            Err(next_line) => LineIndex::from(next_line as u32 - 1),
         }
+    }
+
+    fn location(&self, byte_index: ByteIndex) -> Result<Location, LocationError> {
+        let line_index = self.line_index(byte_index);
+        let line_start_index =
+            self.line_start(line_index)
+                .map_err(|_| LocationError::OutOfBounds {
+                    given: byte_index,
+                    span: self.source_span(),
+                })?;
+        let line_src = self
+            .source
+            .as_ref()
+            .get(line_start_index.to_usize()..byte_index.to_usize())
+            .ok_or_else(|| {
+                let given = byte_index;
+                if given >= self.source_span().end() {
+                    let span = self.source_span();
+                    LocationError::OutOfBounds { given, span }
+                } else {
+                    LocationError::InvalidCharBoundary { given }
+                }
+            })?;
+
+        Ok(Location {
+            line: line_index,
+            column: ColumnIndex::from(line_src.chars().count() as u32),
+        })
     }
 
     fn source(&self) -> &Source {


### PR DESCRIPTION
This will allow clients of `codespan-reporting` to implement their own file databases. This is important if we want to allow users to work with frameworks like Salsa, or have domain-specific concerns with regard to file handling.

Closes #79.