### PR TITLE
Don’t highlight underlined source with mark color

### DIFF
--- a/codespan-reporting/tests/snapshots/term__empty_spans__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__empty_spans__rich_color.snap
@@ -6,7 +6,7 @@ expression: TEST_DATA.emit_color(&config)
 
    {fg:Blue}┌{/}{fg:Blue}──{/} hello:1:7 {fg:Blue}───{/}
    {fg:Blue}│{/}
- {fg:Blue}1{/} {fg:Blue}│{/} Hello {fg:Green}{/}world!
+ {fg:Blue}1{/} {fg:Blue}│{/} Hello world!
    {fg:Blue}│{/}       {fg:Green}^ middle{/}
    {fg:Blue}│{/}
 
@@ -14,7 +14,7 @@ expression: TEST_DATA.emit_color(&config)
 
    {fg:Blue}┌{/}{fg:Blue}──{/} hello:1:13 {fg:Blue}───{/}
    {fg:Blue}│{/}
- {fg:Blue}1{/} {fg:Blue}│{/} Hello world!{fg:Green}{/}
+ {fg:Blue}1{/} {fg:Blue}│{/} Hello world!
    {fg:Blue}│{/}             {fg:Green}^ end of line{/}
    {fg:Blue}│{/}
 
@@ -22,7 +22,7 @@ expression: TEST_DATA.emit_color(&config)
 
    {fg:Blue}┌{/}{fg:Blue}──{/} hello:2:11 {fg:Blue}───{/}
    {fg:Blue}│{/}
- {fg:Blue}2{/} {fg:Blue}│{/} Bye world!{fg:Green}{/}
+ {fg:Blue}2{/} {fg:Blue}│{/} Bye world!
    {fg:Blue}│{/}           {fg:Green}^ end of file{/}
    {fg:Blue}│{/}
 

--- a/codespan-reporting/tests/snapshots/term__fizz_buzz__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__fizz_buzz__rich_color.snap
@@ -6,18 +6,18 @@ expression: TEST_DATA.emit_color(&config)
 
    {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:8:12 {fg:Blue}───{/}
    {fg:Blue}│{/}
- {fg:Blue}8{/} {fg:Blue}│{/}     _ _ => {fg:Red}num{/}
+ {fg:Blue}8{/} {fg:Blue}│{/}     _ _ => num
    {fg:Blue}│{/}            {fg:Red}^^^ expected `String`, found `Nat`{/}
    {fg:Blue}·{/}
- {fg:Blue}4{/} {fg:Blue}│{/}   fizz₁ num = {fg:Blue}case (mod num 5) (mod num 3) of{/}
+ {fg:Blue}4{/} {fg:Blue}│{/}   fizz₁ num = case (mod num 5) (mod num 3) of
    {fg:Blue}│{/} {fg:Blue}╭─────────────'{/}
- {fg:Blue}5{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}     0 0 => "FizzBuzz"{/}
- {fg:Blue}6{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}     0 _ => "Fizz"{/}
- {fg:Blue}7{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}     _ 0 => "Buzz"{/}
- {fg:Blue}8{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}     _ _ => num{/}
+ {fg:Blue}5{/} {fg:Blue}│{/} {fg:Blue}│{/}     0 0 => "FizzBuzz"
+ {fg:Blue}6{/} {fg:Blue}│{/} {fg:Blue}│{/}     0 _ => "Fizz"
+ {fg:Blue}7{/} {fg:Blue}│{/} {fg:Blue}│{/}     _ 0 => "Buzz"
+ {fg:Blue}8{/} {fg:Blue}│{/} {fg:Blue}│{/}     _ _ => num
    {fg:Blue}│{/} {fg:Blue}╰──────────────' `case` clauses have incompatible types{/}
    {fg:Blue}·{/}
- {fg:Blue}3{/} {fg:Blue}│{/} fizz₁ : Nat → {fg:Blue}String{/}
+ {fg:Blue}3{/} {fg:Blue}│{/} fizz₁ : Nat → String
    {fg:Blue}│{/}               {fg:Blue}------ expected type `String` found here{/}
    {fg:Blue}│{/}
    {fg:Blue}={/} expected type `String`
@@ -27,23 +27,23 @@ expression: TEST_DATA.emit_color(&config)
 
     {fg:Blue}┌{/}{fg:Blue}──{/} FizzBuzz.fun:15:16 {fg:Blue}───{/}
     {fg:Blue}│{/}
- {fg:Blue}15{/} {fg:Blue}│{/}         _ _ => {fg:Red}num{/}
+ {fg:Blue}15{/} {fg:Blue}│{/}         _ _ => num
     {fg:Blue}│{/}                {fg:Red}^^^ expected `String`, found `Nat`{/}
     {fg:Blue}·{/}
- {fg:Blue}11{/} {fg:Blue}│{/} {fg:Blue}╭{/}     {fg:Blue}case (mod num 5) (mod num 3) of{/}
- {fg:Blue}12{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}         0 0 => "FizzBuzz"{/}
- {fg:Blue}13{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}         0 _ => "Fizz"{/}
- {fg:Blue}14{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}         _ 0 => "Buzz"{/}
- {fg:Blue}15{/} {fg:Blue}│{/} {fg:Blue}│{/}{fg:Blue}         _ _ => num{/}
+ {fg:Blue}11{/} {fg:Blue}│{/} {fg:Blue}╭{/}     case (mod num 5) (mod num 3) of
+ {fg:Blue}12{/} {fg:Blue}│{/} {fg:Blue}│{/}         0 0 => "FizzBuzz"
+ {fg:Blue}13{/} {fg:Blue}│{/} {fg:Blue}│{/}         0 _ => "Fizz"
+ {fg:Blue}14{/} {fg:Blue}│{/} {fg:Blue}│{/}         _ 0 => "Buzz"
+ {fg:Blue}15{/} {fg:Blue}│{/} {fg:Blue}│{/}         _ _ => num
     {fg:Blue}│{/} {fg:Blue}╰──────────────────' `case` clauses have incompatible types{/}
     {fg:Blue}·{/}
- {fg:Blue}12{/} {fg:Blue}│{/}         0 0 => {fg:Blue}"FizzBuzz"{/}
+ {fg:Blue}12{/} {fg:Blue}│{/}         0 0 => "FizzBuzz"
     {fg:Blue}│{/}                {fg:Blue}---------- this is found to be of type `String`{/}
     {fg:Blue}·{/}
- {fg:Blue}13{/} {fg:Blue}│{/}         0 _ => {fg:Blue}"Fizz"{/}
+ {fg:Blue}13{/} {fg:Blue}│{/}         0 _ => "Fizz"
     {fg:Blue}│{/}                {fg:Blue}------ this is found to be of type `String`{/}
     {fg:Blue}·{/}
- {fg:Blue}14{/} {fg:Blue}│{/}         _ 0 => {fg:Blue}"Buzz"{/}
+ {fg:Blue}14{/} {fg:Blue}│{/}         _ 0 => "Buzz"
     {fg:Blue}│{/}                {fg:Blue}------ this is found to be of type `String`{/}
     {fg:Blue}│{/}
     {fg:Blue}={/} expected type `String`

--- a/codespan-reporting/tests/snapshots/term__multifile__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multifile__rich_color.snap
@@ -6,7 +6,7 @@ expression: TEST_DATA.emit_color(&config)
 
    {fg:Blue}┌{/}{fg:Blue}──{/} Data/Nat.fun:7:13 {fg:Blue}───{/}
    {fg:Blue}│{/}
- {fg:Blue}7{/} {fg:Blue}│{/} {-# BUILTIN {fg:Red}NATRAL{/} Nat #-}
+ {fg:Blue}7{/} {fg:Blue}│{/} {-# BUILTIN NATRAL Nat #-}
    {fg:Blue}│{/}             {fg:Red}^^^^^^ unknown builtin{/}
    {fg:Blue}│{/}
    {fg:Blue}={/} there is a builtin with a similar name: `NATURAL`
@@ -15,7 +15,7 @@ expression: TEST_DATA.emit_color(&config)
 
     {fg:Blue}┌{/}{fg:Blue}──{/} Data/Nat.fun:17:16 {fg:Blue}───{/}
     {fg:Blue}│{/}
- {fg:Blue}17{/} {fg:Blue}│{/} zero    - succ {fg:Yellow}n₂{/} = zero
+ {fg:Blue}17{/} {fg:Blue}│{/} zero    - succ n₂ = zero
     {fg:Blue}│{/}                {fg:Yellow}^^ unused parameter{/}
     {fg:Blue}│{/}
     {fg:Blue}={/} consider using a wildcard pattern: `_`
@@ -24,13 +24,13 @@ expression: TEST_DATA.emit_color(&config)
 
    {fg:Blue}┌{/}{fg:Blue}──{/} Test.fun:4:11 {fg:Blue}───{/}
    {fg:Blue}│{/}
- {fg:Blue}4{/} {fg:Blue}│{/} _ = 123 + {fg:Red}"hello"{/}
+ {fg:Blue}4{/} {fg:Blue}│{/} _ = 123 + "hello"
    {fg:Blue}│{/}           {fg:Red}^^^^^^^ expected `Nat`, found `String`{/}
    {fg:Blue}│{/}
 
     {fg:Blue}┌{/}{fg:Blue}──{/} Data/Nat.fun:11:1 {fg:Blue}───{/}
     {fg:Blue}│{/}
- {fg:Blue}11{/} {fg:Blue}│{/} {fg:Blue}_+_ : Nat → Nat → Nat{/}
+ {fg:Blue}11{/} {fg:Blue}│{/} _+_ : Nat → Nat → Nat
     {fg:Blue}│{/} {fg:Blue}--------------------- based on the definition of `_+_`{/}
     {fg:Blue}│{/}
 


### PR DESCRIPTION
This should make it easier to implement grouped labels in the future (see #100), as we won’t have to deal with overlapping colours in the source - only overlapping underlines!