### PR TITLE
Make file ordering more consistent

### DIFF
--- a/codespan-reporting/src/files.rs
+++ b/codespan-reporting/src/files.rs
@@ -92,7 +92,7 @@ where
 /// This is to workaround the lack of higher kinded lifetime parameters.
 /// This can be ignored if this is not needed, however.
 pub trait Files<'a> {
-    type FileId: 'a + Copy + Ord;
+    type FileId: 'a + Copy + PartialEq;
     type Origin: 'a + std::fmt::Display;
     type LineSource: 'a + AsRef<str>;
 

--- a/codespan-reporting/tests/snapshots/term__multifile__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multifile__rich_color.snap
@@ -22,15 +22,15 @@ expression: TEST_DATA.emit_color(&config)
 
 {fg:Red bold bright}error[E0001]{bold bright}: unexpected type in application of `_+_`{/}
 
-    {fg:Blue}┌{/}{fg:Blue}──{/} Data/Nat.fun:11:1 {fg:Blue}───{/}
-    {fg:Blue}│{/}
- {fg:Blue}11{/} {fg:Blue}│{/} _+_ : Nat → Nat → Nat
-    {fg:Blue}│{/} {fg:Blue}--------------------- based on the definition of `_+_`{/}
-    {fg:Blue}│{/}
     {fg:Blue}┌{/}{fg:Blue}──{/} Test.fun:4:11 {fg:Blue}───{/}
     {fg:Blue}│{/}
  {fg:Blue} 4{/} {fg:Blue}│{/} _ = 123 + "hello"
     {fg:Blue}│{/}           {fg:Red}^^^^^^^ expected `Nat`, found `String`{/}
+    {fg:Blue}│{/}
+    {fg:Blue}┌{/}{fg:Blue}──{/} Data/Nat.fun:11:1 {fg:Blue}───{/}
+    {fg:Blue}│{/}
+ {fg:Blue}11{/} {fg:Blue}│{/} _+_ : Nat → Nat → Nat
+    {fg:Blue}│{/} {fg:Blue}--------------------- based on the definition of `_+_`{/}
     {fg:Blue}│{/}
 
 

--- a/codespan-reporting/tests/snapshots/term__multifile__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multifile__rich_no_color.snap
@@ -22,15 +22,15 @@ warning: unused parameter pattern: `n₂`
 
 error[E0001]: unexpected type in application of `_+_`
 
-    ┌── Data/Nat.fun:11:1 ───
-    │
- 11 │ _+_ : Nat → Nat → Nat
-    │ --------------------- based on the definition of `_+_`
-    │
     ┌── Test.fun:4:11 ───
     │
   4 │ _ = 123 + "hello"
     │           ^^^^^^^ expected `Nat`, found `String`
+    │
+    ┌── Data/Nat.fun:11:1 ───
+    │
+ 11 │ _+_ : Nat → Nat → Nat
+    │ --------------------- based on the definition of `_+_`
     │
 
 


### PR DESCRIPTION
In order to address the feedback provided by @Marwes in https://github.com/brendanzab/codespan/pull/161#discussion_r386320583, we now preserve the order in which new files were seen in the diagnostic. Source lines are still output ordered by line index within a file snippet, however.

We might want to revisit this in the future however - I think having some user control over this would be helpful, as opposed to trying to be too ‘smart’. But we need to come up with a nice API for it.