### PR TITLE
Make line_starts function public

### DIFF
--- a/codespan-reporting/src/files.rs
+++ b/codespan-reporting/src/files.rs
@@ -120,7 +120,38 @@ pub struct SimpleFile<Origin, Source> {
     line_starts: Vec<usize>,
 }
 
-fn line_starts<'a>(source: &'a str) -> impl 'a + Iterator<Item = usize> {
+/// Return the starting byte index of each line in the source string.
+///
+/// This can make it easier to implement new `Files` implementations.
+///
+/// # Example
+///
+/// ```rust
+/// use codespan_reporting::files;
+///
+/// let source = "foo\nbar\r\n\nbaz";
+/// let line_starts: Vec<_> = files::line_starts(source).collect();
+///
+/// assert_eq!(
+///     line_starts,
+///     [
+///         0,  // "foo\n"
+///         4,  // "bar\r\n"
+///         9,  // ""
+///         10, // "baz"
+///     ],
+/// );
+///
+/// fn line_index(line_starts: &[usize], byte_index: usize) -> Option<usize> {
+///     match line_starts.binary_search(&byte_index) {
+///         Ok(line) => Some(line),
+///         Err(next_line) => Some(next_line - 1),
+///     }
+/// }
+///
+/// assert_eq!(line_index(&line_starts, 5), Some(1));
+/// ```
+pub fn line_starts<'source>(source: &'source str) -> impl 'source + Iterator<Item = usize> {
     std::iter::once(0).chain(source.match_indices('\n').map(|(i, _)| i + 1))
 }
 

--- a/codespan/src/file.rs
+++ b/codespan/src/file.rs
@@ -341,20 +341,14 @@ struct File<Source> {
     line_starts: Vec<ByteIndex>,
 }
 
-// FIXME: Check file size
-fn compute_line_starts(source: &str) -> Vec<ByteIndex> {
-    std::iter::once(0)
-        .chain(source.match_indices('\n').map(|(i, _)| i as u32 + 1))
-        .map(ByteIndex::from)
-        .collect()
-}
-
 impl<Source> File<Source>
 where
     Source: AsRef<str>,
 {
     fn new(name: OsString, source: Source) -> Self {
-        let line_starts = compute_line_starts(source.as_ref());
+        let line_starts = codespan_reporting::files::line_starts(source.as_ref())
+            .map(|i| ByteIndex::from(i as u32))
+            .collect();
 
         File {
             name,
@@ -364,7 +358,9 @@ where
     }
 
     fn update(&mut self, source: Source) {
-        let line_starts = compute_line_starts(source.as_ref());
+        let line_starts = codespan_reporting::files::line_starts(source.as_ref())
+            .map(|i| ByteIndex::from(i as u32))
+            .collect();
         self.source = source;
         self.line_starts = line_starts;
     }


### PR DESCRIPTION
This can make it easier to implement new `Files` implementations.