### PR TITLE
Remove source field from Line struct

### DIFF
--- a/codespan-reporting/src/term/views/diagnostic.rs
+++ b/codespan-reporting/src/term/views/diagnostic.rs
@@ -172,11 +172,14 @@ where
             primary_labels += 1;
 
             let origin = files.origin(label.file_id).expect("origin");
+            let source = files.source(label.file_id).expect("source");
             let start = label.range.start;
             let line_index = files.line_index(label.file_id, start).expect("line_index");
             let line = files.line(label.file_id, line_index).expect("line");
+            let line_source = &source.as_ref()[line.range.clone()];
 
-            Locus::new(origin, line.number, line.column_number(start)).emit(writer, config)?;
+            Locus::new(origin, line.number, line.column_number(line_source, start))
+                .emit(writer, config)?;
             write!(writer, ": ")?;
             Header::new(self.diagnostic).emit(writer, config)?;
         }

--- a/codespan/src/file.rs
+++ b/codespan/src/file.rs
@@ -301,7 +301,7 @@ where
 {
     type FileId = FileId;
     type Origin = String;
-    type LineSource = &'a str;
+    type Source = &'a str;
 
     fn origin(&self, id: FileId) -> Option<String> {
         use std::path::PathBuf;
@@ -309,22 +309,20 @@ where
         Some(PathBuf::from(self.name(id)).display().to_string())
     }
 
+    fn source(&'a self, id: FileId) -> Option<&str> {
+        Some(self.source(id).as_ref())
+    }
+
     fn line_index(&self, id: FileId, byte_index: usize) -> Option<usize> {
         Some(self.line_index(id, byte_index as u32).to_usize())
     }
 
-    fn line(
-        &'a self,
-        id: FileId,
-        line_index: usize,
-    ) -> Option<codespan_reporting::files::Line<&'a str>> {
+    fn line(&'a self, id: FileId, line_index: usize) -> Option<codespan_reporting::files::Line> {
         let span = self.line_span(id, line_index as u32).ok()?;
-        let source = self.source_slice(id, span).ok()?;
 
         Some(codespan_reporting::files::Line {
-            start: span.start().to_usize(),
             number: line_index + 1,
-            source,
+            range: span.start().to_usize()..span.end().to_usize(),
         })
     }
 }


### PR DESCRIPTION
This makes the rendering code a little more clunky, but I think it makes the API of the `Files` trait a bit nicer for implementors of file databases.