### PR TITLE
Add an example of creating a custom file backends

### DIFF
--- a/codespan-reporting/examples/custom_files.rs
+++ b/codespan-reporting/examples/custom_files.rs
@@ -1,0 +1,178 @@
+//! This example shows how to implement a simple custom file database for use
+//! with `codespan_reporting`.
+//!
+//! This implements a custom database that uses 32-bit file-ids.
+
+use codespan_reporting::diagnostic::{Diagnostic, Label};
+use codespan_reporting::term;
+use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
+use std::ops::Range;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut files = files::Files::new();
+
+    let file_id0 = files.add("0.greeting", "hello world!").unwrap();
+    let file_id1 = files.add("1.greeting", "bye world").unwrap();
+
+    let messages = vec![
+        Message::UnwantedGreetings {
+            greetings: vec![(file_id0, 0..5), (file_id1, 0..3)],
+        },
+        Message::OverTheTopExclamations {
+            exclamations: vec![(file_id0, 11..12)],
+        },
+    ];
+
+    let writer = StandardStream::stderr(ColorChoice::Always);
+    let config = codespan_reporting::term::Config::default();
+    for message in &messages {
+        let writer = &mut writer.lock();
+        term::emit(writer, &config, &files, &message.to_diagnostic())?;
+    }
+
+    Ok(())
+}
+
+/// A module containing the file implementation
+mod files {
+    use codespan_reporting::files;
+    use std::ops::Range;
+
+    /// A file that is backed by an `Arc<String>`.
+    #[derive(Debug, Clone)]
+    struct File {
+        /// The name of the file.
+        name: String,
+        /// The source code of the file.
+        source: String,
+        /// The starting byte indices in the source code.
+        line_starts: Vec<usize>,
+    }
+
+    impl File {
+        fn line_start(&self, line_index: usize) -> Option<usize> {
+            use std::cmp::Ordering;
+
+            match line_index.cmp(&self.line_starts.len()) {
+                Ordering::Less => self.line_starts.get(line_index).cloned(),
+                Ordering::Equal => Some(self.source.len()),
+                Ordering::Greater => None,
+            }
+        }
+    }
+
+    /// An opaque file identifier.
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    pub struct FileId(u32);
+
+    #[derive(Debug, Clone)]
+    pub struct Files {
+        files: Vec<File>,
+    }
+
+    impl Files {
+        /// Create a new files database.
+        pub fn new() -> Files {
+            Files { files: Vec::new() }
+        }
+
+        /// Add a file to the database, returning the handle that can be used to
+        /// refer to it again.
+        pub fn add(
+            &mut self,
+            name: impl Into<String>,
+            source: impl Into<String>,
+        ) -> Option<FileId> {
+            use std::convert::TryFrom;
+
+            let file_id = FileId(u32::try_from(self.files.len()).ok()?);
+            let name = name.into();
+            let source = source.into();
+            let line_starts = files::line_starts(&source).collect();
+
+            self.files.push(File {
+                name,
+                line_starts,
+                source,
+            });
+
+            Some(file_id)
+        }
+
+        /// Get the file corresponding to the given id.
+        fn get(&self, file_id: FileId) -> Option<&File> {
+            self.files.get(file_id.0 as usize)
+        }
+    }
+
+    impl<'files> files::Files<'files> for Files {
+        type FileId = FileId;
+        type Name = &'files str;
+        type Source = &'files str;
+
+        fn name(&self, file_id: FileId) -> Option<&str> {
+            Some(self.get(file_id)?.name.as_ref())
+        }
+
+        fn source(&self, file_id: FileId) -> Option<&str> {
+            Some(&self.get(file_id)?.source)
+        }
+
+        fn line_index(&self, file_id: FileId, byte_index: usize) -> Option<usize> {
+            match self.get(file_id)?.line_starts.binary_search(&byte_index) {
+                Ok(line) => Some(line),
+                Err(next_line) => Some(next_line - 1),
+            }
+        }
+
+        fn line_range(&self, file_id: FileId, line_index: usize) -> Option<Range<usize>> {
+            let file = self.get(file_id)?;
+            let line_start = file.line_start(line_index)?;
+            let next_line_start = file.line_start(line_index + 1)?;
+
+            Some(line_start..next_line_start)
+        }
+    }
+}
+
+/// A Diagnostic message.
+enum Message {
+    UnwantedGreetings {
+        greetings: Vec<(files::FileId, Range<usize>)>,
+    },
+    OverTheTopExclamations {
+        exclamations: Vec<(files::FileId, Range<usize>)>,
+    },
+}
+
+impl Message {
+    fn to_diagnostic(&self) -> Diagnostic<files::FileId> {
+        match self {
+            Message::UnwantedGreetings { greetings } => Diagnostic::error()
+                .with_message("greetings are not allowed")
+                .with_labels(
+                    greetings
+                        .iter()
+                        .map(|(file_id, range)| {
+                            Label::primary(*file_id, range.clone()).with_message("a greeting")
+                        })
+                        .collect(),
+                )
+                .with_notes(vec![
+                    "found greetings!".to_owned(),
+                    "pleas no greetings :(".to_owned(),
+                ]),
+            Message::OverTheTopExclamations { exclamations } => Diagnostic::error()
+                .with_message("over-the-top exclamations")
+                .with_labels(
+                    exclamations
+                        .iter()
+                        .map(|(file_id, range)| {
+                            Label::primary(*file_id, range.clone()).with_message("an exclamation")
+                        })
+                        .collect(),
+                )
+                .with_notes(vec!["ridiculous!".to_owned()]),
+        }
+    }
+}

--- a/codespan-reporting/src/diagnostic.rs
+++ b/codespan-reporting/src/diagnostic.rs
@@ -89,12 +89,16 @@ impl<FileId> Label<FileId> {
         }
     }
 
-    /// Create a new primary label.
+    /// Create a new label with a style of [`LabelStyle::Primary`].
+    ///
+    /// [`LabelStyle::Primary`]: LabelStyle::Primary
     pub fn primary(file_id: FileId, range: impl Into<Range<usize>>) -> Label<FileId> {
         Label::new(LabelStyle::Primary, file_id, range)
     }
 
-    /// Create a new secondary label.
+    /// Create a new label with a style of [`LabelStyle::Secondary`].
+    ///
+    /// [`LabelStyle::Secondary`]: LabelStyle::Secondary
     pub fn secondary(file_id: FileId, range: impl Into<Range<usize>>) -> Label<FileId> {
         Label::new(LabelStyle::Secondary, file_id, range)
     }
@@ -140,27 +144,37 @@ impl<FileId> Diagnostic<FileId> {
         }
     }
 
-    /// Create a new diagnostic with a severity of `Severity::Bug`.
+    /// Create a new diagnostic with a severity of [`Severity::Bug`].
+    ///
+    /// [`Severity::Bug`]: Severity::Bug
     pub fn bug() -> Diagnostic<FileId> {
         Diagnostic::new(Severity::Bug)
     }
 
-    /// Create a new diagnostic with a severity of `Severity::Error`.
+    /// Create a new diagnostic with a severity of [`Severity::Error`].
+    ///
+    /// [`Severity::Error`]: Severity::Error
     pub fn error() -> Diagnostic<FileId> {
         Diagnostic::new(Severity::Error)
     }
 
-    /// Create a new diagnostic with a severity of `Severity::Warning`.
+    /// Create a new diagnostic with a severity of [`Severity::Warning`].
+    ///
+    /// [`Severity::Warning`]: Severity::Warning
     pub fn warning() -> Diagnostic<FileId> {
         Diagnostic::new(Severity::Warning)
     }
 
-    /// Create a new diagnostic with a severity of `Severity::Note`.
+    /// Create a new diagnostic with a severity of [`Severity::Note`].
+    ///
+    /// [`Severity::Note`]: Severity::Note
     pub fn note() -> Diagnostic<FileId> {
         Diagnostic::new(Severity::Note)
     }
 
-    /// Create a new diagnostic with a severity of `Severity::Help`.
+    /// Create a new diagnostic with a severity of [`Severity::Help`].
+    ///
+    /// [`Severity::Help`]: Severity::Help
     pub fn help() -> Diagnostic<FileId> {
         Diagnostic::new(Severity::Help)
     }

--- a/codespan-reporting/src/term.rs
+++ b/codespan-reporting/src/term.rs
@@ -17,14 +17,17 @@ pub use self::config::{Chars, Config, DisplayStyle, Styles};
 
 /// A command line argument that configures the coloring of the output.
 ///
-/// This can be used with command line argument parsers like `clap` or `structopt`.
+/// This can be used with command line argument parsers like [`clap`] or [`structopt`].
+///
+/// [`clap`]: https://crates.io/crates/clap
+/// [`structopt`]: https://crates.io/crates/structopt
 ///
 /// # Example
 ///
 /// ```rust
-/// use structopt::StructOpt;
 /// use codespan_reporting::term::termcolor::StandardStream;
 /// use codespan_reporting::term::ColorArg;
+/// use structopt::StructOpt;
 ///
 /// #[derive(Debug, StructOpt)]
 /// #[structopt(name = "groovey-app")]
@@ -32,10 +35,9 @@ pub use self::config::{Chars, Config, DisplayStyle, Styles};
 ///     /// Configure coloring of output
 ///     #[structopt(
 ///         long = "color",
-///         parse(try_from_str),
 ///         default_value = "auto",
 ///         possible_values = ColorArg::VARIANTS,
-///         case_insensitive = true
+///         case_insensitive = true,
 ///     )]
 ///     pub color: ColorArg,
 /// }
@@ -51,8 +53,11 @@ pub struct ColorArg(pub ColorChoice);
 impl ColorArg {
     /// Allowed values the argument.
     ///
-    /// This is useful for generating documentation via `clap` or `structopt`'s
+    /// This is useful for generating documentation via [`clap`] or `structopt`'s
     /// `possible_values` configuration.
+    ///
+    /// [`clap`]: https://crates.io/crates/clap
+    /// [`structopt`]: https://crates.io/crates/structopt
     pub const VARIANTS: &'static [&'static str] = &["auto", "always", "ansi", "never"];
 }
 

--- a/codespan-reporting/src/term/config.rs
+++ b/codespan-reporting/src/term/config.rs
@@ -7,7 +7,9 @@ use crate::diagnostic::Severity;
 #[derive(Clone, Debug)]
 pub struct Config {
     /// The display style to use when rendering diagnostics.
-    /// Defaults to: `DisplayStyle::Rich`.
+    /// Defaults to: [`DisplayStyle::Rich`].
+    ///
+    /// [`DisplayStyle::Rich`]: DisplayStyle::Rich
     pub display_style: DisplayStyle,
     /// Column width of tabs.
     /// Defaults to: `4`.


### PR DESCRIPTION
There has been some confusion over how hard/how to make custom implementations of the `Files` trait. I think it's probably good if we provide an example of what this looks like.