### PR TITLE
Add peg example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.36.0", "stable", "beta", "nightly"]
+        rust: ["1.40.0", "stable", "beta", "nightly"]
     name: Check (${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.36.0", "stable", "beta", "nightly"]
+        rust: ["1.40.0", "stable", "beta", "nightly"]
     name: Test Suite (${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v2
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.36.0", "stable", "beta", "nightly"]
+        rust: ["1.40.0", "stable", "beta", "nightly"]
     name: Rustfmt (${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v2

--- a/codespan-reporting/Cargo.toml
+++ b/codespan-reporting/Cargo.toml
@@ -17,6 +17,7 @@ termcolor = "1"
 unicode-width = "0.1"
 
 [dev-dependencies]
+anyhow = "1"
 insta = "0.15"
 lazy_static = "1.4"
 structopt = "0.3"

--- a/codespan-reporting/Cargo.toml
+++ b/codespan-reporting/Cargo.toml
@@ -20,6 +20,8 @@ unicode-width = "0.1"
 anyhow = "1"
 insta = "0.15"
 lazy_static = "1.4"
+peg = "0.6"
+rustyline = "6"
 structopt = "0.3"
 unindent = "0.1"
 

--- a/codespan-reporting/examples/custom_files.rs
+++ b/codespan-reporting/examples/custom_files.rs
@@ -8,7 +8,7 @@ use codespan_reporting::term;
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
 use std::ops::Range;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> anyhow::Result<()> {
     let mut files = files::Files::new();
 
     let file_id0 = files.add("0.greeting", "hello world!").unwrap();

--- a/codespan-reporting/examples/peg_calculator.rs
+++ b/codespan-reporting/examples/peg_calculator.rs
@@ -30,7 +30,7 @@ peg::parser! {
             v:@   "!"       { (1..v+1).product() }
             --
             "(" v:calculate() ")" { v }
-            n:number() {n}
+            n:number() { n }
         }
     }
 }
@@ -41,7 +41,7 @@ fn main() -> anyhow::Result<()> {
     let mut editor = Editor::<()>::new();
 
     loop {
-        let line = match editor.readline(&"> ") {
+        let line = match editor.readline("> ") {
             Ok(line) => line,
             Err(ReadlineError::Interrupted) | Err(ReadlineError::Eof) => return Ok(()),
             Err(error) => return Err(error.into()),

--- a/codespan-reporting/examples/peg_calculator.rs
+++ b/codespan-reporting/examples/peg_calculator.rs
@@ -1,0 +1,67 @@
+//! An example of using `peg` with `codespan_reporting`.
+//!
+//! To run this example execute the following command from the top level of this repository:
+//!
+//! ```sh
+//! cargo run --example peg_calculator
+//! ```
+
+use codespan_reporting::diagnostic::{Diagnostic, Label};
+use codespan_reporting::files::SimpleFile;
+use codespan_reporting::term;
+use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
+use rustyline::error::ReadlineError;
+use rustyline::Editor;
+
+peg::parser! {
+    grammar arithmetic() for str {
+        rule number() -> i64
+            = n:$(['0'..='9']+) { n.parse().unwrap() }
+
+        pub rule calculate() -> i64 = precedence!{
+            x:(@) "+" y:@ { x + y }
+            x:(@) "-" y:@ { x - y }
+                  "-" v:@ { - v }
+            --
+            x:(@) "*" y:@ { x * y }
+            x:(@) "/" y:@ { x / y }
+            --
+            x:@   "^" y:(@) { i64::pow(x, y as u32) }
+            v:@   "!"       { (1..v+1).product() }
+            --
+            "(" v:calculate() ")" { v }
+            n:number() {n}
+        }
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let writer = StandardStream::stderr(ColorChoice::Always);
+    let config = codespan_reporting::term::Config::default();
+    let mut editor = Editor::<()>::new();
+
+    loop {
+        let line = match editor.readline(&"> ") {
+            Ok(line) => line,
+            Err(ReadlineError::Interrupted) | Err(ReadlineError::Eof) => return Ok(()),
+            Err(error) => return Err(error.into()),
+        };
+
+        match arithmetic::calculate(&line) {
+            Ok(number) => println!("{}", number),
+            Err(error) => {
+                let file = SimpleFile::new("input", line);
+
+                let start = error.location.offset;
+                let diagnostic = Diagnostic::error()
+                    .with_message("parse error")
+                    .with_labels(vec![
+                        Label::primary((), start..start).with_message("parse error")
+                    ])
+                    .with_notes(vec![format!("expected: {}", error.expected)]);
+
+                term::emit(&mut writer.lock(), &config, &file, &diagnostic)?;
+            }
+        }
+    }
+}

--- a/codespan-reporting/examples/sample.rs
+++ b/codespan-reporting/examples/sample.rs
@@ -92,7 +92,7 @@ const SVG_END: &str = "</pre>
 </svg>
 ";
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> anyhow::Result<()> {
     let file = SimpleFile::new(
         "FizzBuzz.fun",
         unindent::unindent(
@@ -144,7 +144,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             write!(writer, "{}", SVG_START)?;
             for diagnostic in &diagnostics {
-                term::emit(&mut writer, &config, &file, &diagnostic).unwrap();
+                term::emit(&mut writer, &config, &file, &diagnostic)?;
             }
             write!(writer, "{}", SVG_END)?;
         }
@@ -152,7 +152,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let writer = StandardStream::stderr(color.into());
             let config = codespan_reporting::term::Config::default();
             for diagnostic in &diagnostics {
-                term::emit(&mut writer.lock(), &config, &file, &diagnostic).unwrap();
+                term::emit(&mut writer.lock(), &config, &file, &diagnostic)?;
             }
         }
     }

--- a/codespan-reporting/examples/term.rs
+++ b/codespan-reporting/examples/term.rs
@@ -18,7 +18,7 @@ pub struct Opts {
     pub color: ColorArg,
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let opts = Opts::from_args();
     let mut files = SimpleFiles::new();
 
@@ -155,6 +155,8 @@ fn main() {
     let writer = StandardStream::stderr(opts.color.into());
     let config = codespan_reporting::term::Config::default();
     for diagnostic in &diagnostics {
-        term::emit(&mut writer.lock(), &config, &files, &diagnostic).unwrap();
+        term::emit(&mut writer.lock(), &config, &files, &diagnostic)?;
     }
+
+    Ok(())
 }


### PR DESCRIPTION
As part of #102, this adds an example using the peg parser generator crate.

Example session:

<img width="375" alt="Example session" src="https://user-images.githubusercontent.com/695077/76294409-e91a7400-6306-11ea-83dd-baf20af436fa.png">
