### PR TITLE
Allow for custom user-facing column numbers

### DIFF
--- a/codespan-reporting/src/files.rs
+++ b/codespan-reporting/src/files.rs
@@ -158,9 +158,10 @@ pub fn column_index(source: &str, line_range: Range<usize>, byte_index: usize) -
 /// Return the starting byte index of each line in the source string.
 ///
 /// This can make it easier to implement [`Files::line_index`] by allowing
-/// users to pre-compute the line starts, then search for the matching line
-/// range, as shown in the example below.
+/// implementors of [`Files`] to pre-compute the line starts, then search for
+/// the corresponding line range, as shown in the example below.
 ///
+/// [`Files`]: Files
 /// [`Files::line_index`]: Files::line_index
 ///
 /// # Example

--- a/codespan-reporting/src/files.rs
+++ b/codespan-reporting/src/files.rs
@@ -93,8 +93,32 @@ pub trait Files<'a> {
         Some(column_number(source.as_ref(), line_range, byte_index))
     }
 
+    /// Convenience method for returning line and column number at the given a
+    /// byte index in the file.
+    fn location(&'a self, id: Self::FileId, byte_index: usize) -> Option<Location> {
+        let line_index = self.line_index(id, byte_index)?;
+
+        Some(Location {
+            line_number: self.line_number(id, line_index)?,
+            column_number: self.column_number(id, line_index, byte_index)?,
+        })
+    }
+
     /// The byte range of line in the source of the file.
     fn line_range(&'a self, id: Self::FileId, line_index: usize) -> Option<Range<usize>>;
+}
+
+/// A user-facing location in a source file.
+///
+/// Returned by [`Files::location`].
+///
+/// [`Files::location`]: Files::location
+#[derive(Debug, Copy, Clone)]
+pub struct Location {
+    /// The user-facing line number.
+    pub line_number: usize,
+    /// The user-facing column number.
+    pub column_number: usize,
 }
 
 /// The column index at the given byte index in the source file.

--- a/codespan-reporting/src/term/renderer.rs
+++ b/codespan-reporting/src/term/renderer.rs
@@ -3,16 +3,15 @@ use std::ops::{Range, RangeTo};
 use termcolor::{ColorSpec, WriteColor};
 
 use crate::diagnostic::Severity;
+use crate::files::Location;
 use crate::term::{Chars, Config, Styles};
 
 /// The 'location focus' of a source code snippet.
 pub struct Locus {
     /// The user-facing name of the file.
     pub name: String,
-    /// The line number.
-    pub line_number: usize,
-    /// The column number.
-    pub column_number: usize,
+    /// The location.
+    pub location: Location,
 }
 
 /// A mark to render.
@@ -375,8 +374,8 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
             self,
             "{origin}:{line_number}:{column_number}",
             origin = locus.name,
-            line_number = locus.line_number,
-            column_number = locus.column_number,
+            line_number = locus.location.line_number,
+            column_number = locus.location.column_number,
         )
     }
 

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use crate::diagnostic::{Diagnostic, LabelStyle};
-use crate::files::{self, Files};
+use crate::files::Files;
 use crate::term::renderer::{Locus, Mark, Renderer};
 
 /// Count the number of decimal digits in `n`.
@@ -120,14 +120,15 @@ where
             // ```
             if let Some(label) = labels.peek() {
                 let start_index = files.line_index(file_id, label.range.start).unwrap();
-                let start_range = files.line_range(file_id, start_index).unwrap();
 
                 renderer.render_source_start(
                     outer_padding,
                     &Locus {
                         name: files.name(file_id).unwrap().to_string(),
                         line_number: files.line_number(file_id, start_index).unwrap(),
-                        column_number: files::column_number(source, start_range, label.range.start),
+                        column_number: files
+                            .column_number(label.file_id, start_index, label.range.start)
+                            .unwrap(),
                     },
                 )?;
                 renderer.render_source_empty(outer_padding, &[])?;
@@ -337,16 +338,15 @@ where
         for label in labels.filter(|label| label.style == LabelStyle::Primary) {
             primary_labels_encountered += 1;
 
-            let source = files.source(label.file_id).unwrap();
-            let source = source.as_ref();
             let line_index = files.line_index(label.file_id, label.range.start).unwrap();
-            let line_range = files.line_range(label.file_id, line_index).unwrap();
 
             renderer.render_header(
                 Some(&Locus {
                     name: files.name(label.file_id).unwrap().to_string(),
                     line_number: files.line_number(label.file_id, line_index).unwrap(),
-                    column_number: files::column_number(source, line_range, label.range.start),
+                    column_number: files
+                        .column_number(label.file_id, line_index, label.range.start)
+                        .unwrap(),
                 }),
                 self.diagnostic.severity,
                 self.diagnostic.code.as_ref().map(String::as_str),

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -119,16 +119,11 @@ where
             // ┌── test:2:9 ───
             // ```
             if let Some(label) = labels.peek() {
-                let start_index = files.line_index(file_id, label.range.start).unwrap();
-
                 renderer.render_source_start(
                     outer_padding,
                     &Locus {
                         name: files.name(file_id).unwrap().to_string(),
-                        line_number: files.line_number(file_id, start_index).unwrap(),
-                        column_number: files
-                            .column_number(label.file_id, start_index, label.range.start)
-                            .unwrap(),
+                        location: files.location(file_id, label.range.start).unwrap(),
                     },
                 )?;
                 renderer.render_source_empty(outer_padding, &[])?;
@@ -338,15 +333,10 @@ where
         for label in labels.filter(|label| label.style == LabelStyle::Primary) {
             primary_labels_encountered += 1;
 
-            let line_index = files.line_index(label.file_id, label.range.start).unwrap();
-
             renderer.render_header(
                 Some(&Locus {
                     name: files.name(label.file_id).unwrap().to_string(),
-                    line_number: files.line_number(label.file_id, line_index).unwrap(),
-                    column_number: files
-                        .column_number(label.file_id, line_index, label.range.start)
-                        .unwrap(),
+                    location: files.location(label.file_id, label.range.start).unwrap(),
                 }),
                 self.diagnostic.severity,
                 self.diagnostic.code.as_ref().map(String::as_str),


### PR DESCRIPTION
This addresses an asymmetry in the API that was bugging me - the fact that you can define custom line numbers, but not custom column numbers.