### PR TITLE
Bump cargo version to v0.9.0

### DIFF
--- a/codespan-lsp/CHANGELOG.md
+++ b/codespan-lsp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2020-03-11
+
 ### Changed
 
 -  The `lsp-types` dependency was updated to use a version range: `>=0.70,<0.74`,
@@ -29,7 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1] - 2019-02-26
 ## [0.2.0] - 2018-10-11
 
-[Unreleased]: https://github.com/brendanzab/codespan/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/brendanzab/codespan/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/brendanzab/codespan/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/brendanzab/codespan/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/brendanzab/codespan/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/brendanzab/codespan/compare/v0.5.0...v0.6.0

--- a/codespan-lsp/Cargo.toml
+++ b/codespan-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codespan-lsp"
-version = "0.8.0"
+version = "0.9.0"
 license = "Apache-2.0"
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 description = "Conversions between codespan types and Language Server Protocol types"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/codespan-lsp"
 edition = "2018"
 
 [dependencies]
-codespan = { version = "0.8.0", path = "../codespan" }
+codespan = { version = "0.9.0", path = "../codespan" }
 # WARNING: Be extremely careful when expanding this version range.
 # We should be confident that all of the uses of `lsp-types` in `codespan-lsp`
 # will be valid for all the versions in this range. Getting this range wrong

--- a/codespan-reporting/CHANGELOG.md
+++ b/codespan-reporting/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2020-03-11
+
 ### Added
 
 -   The `codespan_reporting::files` was added as a way to decouple
@@ -53,7 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1] - 2019-02-26
 ## [0.2.0] - 2018-10-11
 
-[Unreleased]: https://github.com/brendanzab/codespan/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/brendanzab/codespan/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/brendanzab/codespan/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/brendanzab/codespan/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/brendanzab/codespan/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/brendanzab/codespan/compare/v0.5.0...v0.6.0

--- a/codespan-reporting/Cargo.toml
+++ b/codespan-reporting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codespan-reporting"
-version = "0.8.0"
+version = "0.9.0"
 readme = "../README.md"
 license = "Apache-2.0"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>"]

--- a/codespan/CHANGELOG.md
+++ b/codespan/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2020-03-11
+
 ### Added
 
 - `codespan` now depends on `codespan_reporting`. This can be disabled via the `reporting` feature.
@@ -22,7 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1] - 2019-02-26
 ## [0.2.0] - 2018-10-11
 
-[Unreleased]: https://github.com/brendanzab/codespan/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/brendanzab/codespan/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/brendanzab/codespan/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/brendanzab/codespan/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/brendanzab/codespan/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/brendanzab/codespan/compare/v0.5.0...v0.6.0

--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codespan"
-version = "0.8.0"
+version = "0.9.0"
 readme = "README.md"
 license = "Apache-2.0"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>"]
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/codespan"
 edition = "2018"
 
 [dependencies]
-codespan-reporting = { path = "../codespan-reporting", version = "0.8.0", optional = true }
+codespan-reporting = { path = "../codespan-reporting", version = "0.9.0", optional = true }
 serde = { version = "1", optional = true, features = ["derive"]}
 
 [features]


### PR DESCRIPTION
More details on what has changed in this release can be found in the changelogs:

- [codespan-reporting/CHANGELOG.md](https://github.com/brendanzab/codespan/blob/master/codespan-reporting/CHANGELOG.md#0.9.0)
- [codespan/CHANGELOG.md](https://github.com/brendanzab/codespan/blob/master/codespan/CHANGELOG.md#0.9.0)
- [codespan-lsp/CHANGELOG.md](https://github.com/brendanzab/codespan/blob/master/codespan-lsp/CHANGELOG.md#0.9.0)

Closes #186.