### PR TITLE
Start using a version range for lsp-types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,17 @@ jobs:
         with:
           command: check
           args: --manifest-path "codespan-lsp/Cargo.toml"
+      - name: Switch to minimal `lsp-types` version
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
+          # NOTE: Keep up to date with the minimum version of `lsp-types`
+          # specified in `codespan-lsp/Cargo.toml`
+          args: --precise lsp-types:0.70
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path "codespan-lsp/Cargo.toml"
 
   test:
     runs-on: ubuntu-latest

--- a/codespan-lsp/CHANGELOG.md
+++ b/codespan-lsp/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--  `lsp-types` was updated to v0.73
+-  The `lsp-types` dependency was updated to use a version range: `>=0.70,<0.74`,
+   which includes the latest updates in `0.73.0`.
 
 ### Removed
 

--- a/codespan-lsp/Cargo.toml
+++ b/codespan-lsp/Cargo.toml
@@ -11,5 +11,5 @@ edition = "2018"
 
 [dependencies]
 codespan = { version = "0.8.0", path = "../codespan" }
-lsp-types = "0.73"
+lsp-types = ">=0.70,<0.74"
 url = "2"

--- a/codespan-lsp/Cargo.toml
+++ b/codespan-lsp/Cargo.toml
@@ -11,5 +11,10 @@ edition = "2018"
 
 [dependencies]
 codespan = { version = "0.8.0", path = "../codespan" }
+# WARNING: Be extremely careful when expanding this version range.
+# We should be confident that all of the uses of `lsp-types` in `codespan-lsp`
+# will be valid for all the versions in this range. Getting this range wrong
+# could potentially break down-stream builds on a `cargo update`. This is an
+# absolute no-no, breaking much of what we enjoy about Cargo!
 lsp-types = ">=0.70,<0.74"
 url = "2"


### PR DESCRIPTION
Based on discussions on #180 and gluon-lang/lsp-types#117, this switches us to use a version range (`>=0.70,<0.74`) for our dependency on `lsp-types`, seeing as we only use a couple of types from this repository (`lsp_types::{Position, Range}`) that don’t change very often. This will mean that we can make releases of `codespan-lsp` that update the maximum version _without_ breaking backwards compatibility for consumers.