### PR TITLE
Avoid rendering multiple source lines when labels are on one line

### DIFF
--- a/codespan-reporting/tests/snapshots/term__one_line__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__one_line__rich_color.snap
@@ -8,11 +8,7 @@ expression: TEST_DATA.emit_color(&config)
    {fg:Blue}│{/}
  {fg:Blue}3{/} {fg:Blue}│{/}     v.push(v.pop().unwrap());
    {fg:Blue}│{/}     {fg:Blue}- first borrow later used by call{/}
-   {fg:Blue}·{/}
- {fg:Blue}3{/} {fg:Blue}│{/}     v.push(v.pop().unwrap());
    {fg:Blue}│{/}       {fg:Blue}---- first mutable borrow occurs here{/}
-   {fg:Blue}·{/}
- {fg:Blue}3{/} {fg:Blue}│{/}     v.push(v.pop().unwrap());
    {fg:Blue}│{/}            {fg:Red}^ second mutable borrow occurs here{/}
    {fg:Blue}│{/}
 

--- a/codespan-reporting/tests/snapshots/term__one_line__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__one_line__rich_no_color.snap
@@ -8,11 +8,7 @@ error[E0499]: cannot borrow `v` as mutable more than once at a time
    │
  3 │     v.push(v.pop().unwrap());
    │     - first borrow later used by call
-   ·
- 3 │     v.push(v.pop().unwrap());
    │       ---- first mutable borrow occurs here
-   ·
- 3 │     v.push(v.pop().unwrap());
    │            ^ second mutable borrow occurs here
    │
 


### PR DESCRIPTION
As another step towards #100, this means that this:
```
   ┌── one_line.rs:3:5 ───
   │
 3 │     v.push(v.pop().unwrap());
   │     - first borrow later used by call
   ·
 3 │     v.push(v.pop().unwrap());
   │       ---- first mutable borrow occurs here
   ·
 3 │     v.push(v.pop().unwrap());
   │            ^ second mutable borrow occurs here
   │
```
…is now rendered as:
```
   ┌── one_line.rs:3:5 ───
   │
 3 │     v.push(v.pop().unwrap());
   │     - first borrow later used by call
   │       ---- first mutable borrow occurs here
   │            ^ second mutable borrow occurs here
   │
```
We’ll eventually want to use vertical lines like rustc does to make this clearer, eg:
```
  --> $DIR/one_line.rs:3:12
   |
LL |     v.push(v.pop().unwrap());
   |     - ---- ^ second mutable borrow occurs here
   |     | |
   |     | first borrow later used by call
   |     first mutable borrow occurs here
```