### PR TITLE
Implement some conversions for indexes and spans

### DIFF
--- a/codespan/src/index.rs
+++ b/codespan/src/index.rs
@@ -332,6 +332,34 @@ macro_rules! impl_index {
             }
         }
 
+        impl From<$Index> for RawIndex {
+            #[inline]
+            fn from(index: $Index) -> RawIndex {
+                index.0
+            }
+        }
+
+        impl From<$Offset> for RawOffset {
+            #[inline]
+            fn from(offset: $Offset) -> RawOffset {
+                offset.0
+            }
+        }
+
+        impl From<$Index> for usize {
+            #[inline]
+            fn from(index: $Index) -> usize {
+                index.0 as usize
+            }
+        }
+
+        impl From<$Offset> for usize {
+            #[inline]
+            fn from(offset: $Offset) -> usize {
+                offset.0 as usize
+            }
+        }
+
         impl Offset for $Offset {
             const ZERO: $Offset = $Offset(0);
         }

--- a/codespan/src/span.rs
+++ b/codespan/src/span.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::Range;
 
-use crate::ByteIndex;
+use crate::{ByteIndex, RawIndex};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
@@ -134,6 +134,18 @@ where
 {
     fn from(range: Range<I>) -> Span {
         Span::new(range.start, range.end)
+    }
+}
+
+impl From<Span> for Range<usize> {
+    fn from(span: Span) -> Range<usize> {
+        span.start.into()..span.end.into()
+    }
+}
+
+impl From<Span> for Range<RawIndex> {
+    fn from(span: Span) -> Range<RawIndex> {
+        span.start.0..span.end.0
     }
 }
 


### PR DESCRIPTION
As I've said in the past, I'd like to continue to nudge people towards using `codespan-reporting` with `codespan_reporting::files::SimpleFiles` or their own implementation of `codespan_reporting::files::Files`, but this could help people who are currently using `codespan` more work with the new diagnostic data types in a cleaner way.