### PR TITLE
Render overlapping multiline labels properly

### DIFF
--- a/codespan-reporting/assets/readme_preview.svg
+++ b/codespan-reporting/assets/readme_preview.svg
@@ -53,26 +53,21 @@
       <pre><span class="fg red bold bright">error[E0308]</span><span class="bold bright">: `case` clauses have incompatible types</span>
 
     <span class="fg blue">┌──</span> FizzBuzz.fun:10:15 <span class="fg blue">───</span>
-    <span class="fg blue">│</span>
+    <span class="fg blue">│</span>  
  <span class="fg blue">10</span> <span class="fg blue">│</span>   fizz₂ : Nat → String
     <span class="fg blue">│</span>                 <span class="fg blue">------ expected type `String` found here</span>
  <span class="fg blue">11</span> <span class="fg blue">│</span>   fizz₂ num =
  <span class="fg blue">12</span> <span class="fg blue">│</span> <span class="fg blue">╭</span>     case (mod num 5) (mod num 3) of
  <span class="fg blue">13</span> <span class="fg blue">│</span> <span class="fg blue">│</span>         0 0 => "FizzBuzz"
+    <span class="fg blue">│</span> <span class="fg blue">│</span>                <span class="fg blue">---------- this is found to be of type `String`</span>
  <span class="fg blue">14</span> <span class="fg blue">│</span> <span class="fg blue">│</span>         0 _ => "Fizz"
+    <span class="fg blue">│</span> <span class="fg blue">│</span>                <span class="fg blue">------ this is found to be of type `String`</span>
  <span class="fg blue">15</span> <span class="fg blue">│</span> <span class="fg blue">│</span>         _ 0 => "Buzz"
+    <span class="fg blue">│</span> <span class="fg blue">│</span>                <span class="fg blue">------ this is found to be of type `String`</span>
  <span class="fg blue">16</span> <span class="fg blue">│</span> <span class="fg blue">│</span>         _ _ => num
+    <span class="fg blue">│</span> <span class="fg blue">│</span>                <span class="fg red">^^^ expected `String`, found `Nat`</span>
     <span class="fg blue">│</span> <span class="fg blue">╰</span><span class="fg blue">──────────────────' `case` clauses have incompatible types</span>
-    <span class="fg blue">·</span>
- <span class="fg blue">13</span> <span class="fg blue">│</span>           0 0 => "FizzBuzz"
-    <span class="fg blue">│</span>                  <span class="fg blue">---------- this is found to be of type `String`</span>
- <span class="fg blue">14</span> <span class="fg blue">│</span>           0 _ => "Fizz"
-    <span class="fg blue">│</span>                  <span class="fg blue">------ this is found to be of type `String`</span>
- <span class="fg blue">15</span> <span class="fg blue">│</span>           _ 0 => "Buzz"
-    <span class="fg blue">│</span>                  <span class="fg blue">------ this is found to be of type `String`</span>
- <span class="fg blue">16</span> <span class="fg blue">│</span>           _ _ => num
-    <span class="fg blue">│</span>                  <span class="fg red">^^^ expected `String`, found `Nat`</span>
-    <span class="fg blue">│</span>
+    <span class="fg blue">│</span>  
     <span class="fg blue">=</span> expected type `String`
          found type `Nat`
 

--- a/codespan-reporting/src/term/renderer.rs
+++ b/codespan-reporting/src/term/renderer.rs
@@ -245,7 +245,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
                         self.mark_multi_left(*severity, None)?;
                     }
                     // Write a space
-                    Some(Mark::MultiTop(..)) | None => write!(self, "  ")?,
+                    Some(Mark::MultiTop(..)) | None => self.mark_inner_gutter_space(None)?,
                 }
             }
 
@@ -310,7 +310,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         self.border_left()?;
         for left_severity in left_marks {
             match left_severity {
-                None => write!(self, "  ")?,
+                None => self.mark_inner_gutter_space(None)?,
                 Some(severity) => self.mark_multi_left(*severity, None)?,
             }
         }
@@ -333,7 +333,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         self.border_left_break()?;
         for left_severity in left_marks {
             match left_severity {
-                None => write!(self, "  ")?,
+                None => self.mark_inner_gutter_space(None)?,
                 Some(severity) => self.mark_multi_left(*severity, None)?,
             }
         }

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -193,10 +193,10 @@ where
                     let mark_start = label.range.start - start_line_range.start;
                     let mark_end = label.range.end - start_line_range.start;
 
-                    let mark = Mark::Single(mark_start..mark_end, &label.message);
+                    let mark = Mark::Single(severity, mark_start..mark_end, &label.message);
                     let mut marks = match seen_multiline {
-                        true => vec![None, Some((severity, mark))],
-                        false => vec![Some((severity, mark))],
+                        true => vec![None, Some(mark)],
+                        false => vec![Some(mark)],
                     };
 
                     // Accumulate consecutive single marks
@@ -217,9 +217,12 @@ where
                         {
                             let mark_start = next_label.range.start - start_line_range.start;
                             let mark_end = next_label.range.end - start_line_range.start;
-                            let next_mark = Mark::Single(mark_start..mark_end, &next_label.message);
 
-                            marks.push(Some((severity, next_mark)));
+                            marks.push(Some(Mark::Single(
+                                severity,
+                                mark_start..mark_end,
+                                &next_label.message,
+                            )));
                         } else {
                             break;
                         }
@@ -259,7 +262,7 @@ where
                             outer_padding,
                             start_line_number,
                             &source[start_line_range],
-                            &[Some((severity, Mark::MultiTopLeft))],
+                            &[Some(Mark::MultiTopLeft(severity))],
                         )?;
                     } else {
                         // There's source code in the prefix, so run an underline
@@ -273,7 +276,7 @@ where
                             outer_padding,
                             start_line_number,
                             &source[start_line_range],
-                            &[Some((severity, Mark::MultiTop(..mark_start)))],
+                            &[Some(Mark::MultiTop(severity, ..mark_start))],
                         )?;
                     }
 
@@ -289,7 +292,7 @@ where
                             outer_padding,
                             files.line_number(file_id, marked_line_index).unwrap(),
                             &source[files.line_range(file_id, marked_line_index).unwrap()],
-                            &[Some((severity, Mark::MultiLeft))],
+                            &[Some(Mark::MultiLeft(severity))],
                         )?;
                     }
 
@@ -305,9 +308,10 @@ where
                         outer_padding,
                         end_line_number,
                         &source[end_line_range],
-                        &[Some((
+                        &[Some(Mark::MultiBottom(
                             severity,
-                            Mark::MultiBottom(..mark_end, &label.message),
+                            ..mark_end,
+                            &label.message,
                         ))],
                     )?;
                 }

--- a/codespan-reporting/tests/snapshots/term__fizz_buzz__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__fizz_buzz__rich_color.snap
@@ -5,7 +5,7 @@ expression: TEST_DATA.emit_color(&config)
 {fg:Red bold bright}error[E0308]{bold bright}: `case` clauses have incompatible types{/}
 
    {fg:Blue}┌──{/} FizzBuzz.fun:3:15 {fg:Blue}───{/}
-   {fg:Blue}│{/}
+   {fg:Blue}│{/}  
  {fg:Blue}3{/} {fg:Blue}│{/}   fizz₁ : Nat → String
    {fg:Blue}│{/}                 {fg:Blue}------ expected type `String` found here{/}
  {fg:Blue}4{/} {fg:Blue}│{/}   fizz₁ num = case (mod num 5) (mod num 3) of
@@ -14,37 +14,30 @@ expression: TEST_DATA.emit_color(&config)
  {fg:Blue}6{/} {fg:Blue}│{/} {fg:Blue}│{/}     0 _ => "Fizz"
  {fg:Blue}7{/} {fg:Blue}│{/} {fg:Blue}│{/}     _ 0 => "Buzz"
  {fg:Blue}8{/} {fg:Blue}│{/} {fg:Blue}│{/}     _ _ => num
+   {fg:Blue}│{/} {fg:Blue}│{/}            {fg:Red}^^^ expected `String`, found `Nat`{/}
    {fg:Blue}│{/} {fg:Blue}╰{/}{fg:Blue}──────────────' `case` clauses have incompatible types{/}
-   {fg:Blue}·{/}
- {fg:Blue}8{/} {fg:Blue}│{/}       _ _ => num
-   {fg:Blue}│{/}              {fg:Red}^^^ expected `String`, found `Nat`{/}
-   {fg:Blue}│{/}
+   {fg:Blue}│{/}  
    {fg:Blue}={/} expected type `String`
         found type `Nat`
 
 {fg:Red bold bright}error[E0308]{bold bright}: `case` clauses have incompatible types{/}
 
     {fg:Blue}┌──{/} FizzBuzz.fun:10:15 {fg:Blue}───{/}
-    {fg:Blue}│{/}
+    {fg:Blue}│{/}  
  {fg:Blue}10{/} {fg:Blue}│{/}   fizz₂ : Nat → String
     {fg:Blue}│{/}                 {fg:Blue}------ expected type `String` found here{/}
  {fg:Blue}11{/} {fg:Blue}│{/}   fizz₂ num =
  {fg:Blue}12{/} {fg:Blue}│{/} {fg:Blue}╭{/}     case (mod num 5) (mod num 3) of
  {fg:Blue}13{/} {fg:Blue}│{/} {fg:Blue}│{/}         0 0 => "FizzBuzz"
+    {fg:Blue}│{/} {fg:Blue}│{/}                {fg:Blue}---------- this is found to be of type `String`{/}
  {fg:Blue}14{/} {fg:Blue}│{/} {fg:Blue}│{/}         0 _ => "Fizz"
+    {fg:Blue}│{/} {fg:Blue}│{/}                {fg:Blue}------ this is found to be of type `String`{/}
  {fg:Blue}15{/} {fg:Blue}│{/} {fg:Blue}│{/}         _ 0 => "Buzz"
+    {fg:Blue}│{/} {fg:Blue}│{/}                {fg:Blue}------ this is found to be of type `String`{/}
  {fg:Blue}16{/} {fg:Blue}│{/} {fg:Blue}│{/}         _ _ => num
+    {fg:Blue}│{/} {fg:Blue}│{/}                {fg:Red}^^^ expected `String`, found `Nat`{/}
     {fg:Blue}│{/} {fg:Blue}╰{/}{fg:Blue}──────────────────' `case` clauses have incompatible types{/}
-    {fg:Blue}·{/}
- {fg:Blue}13{/} {fg:Blue}│{/}           0 0 => "FizzBuzz"
-    {fg:Blue}│{/}                  {fg:Blue}---------- this is found to be of type `String`{/}
- {fg:Blue}14{/} {fg:Blue}│{/}           0 _ => "Fizz"
-    {fg:Blue}│{/}                  {fg:Blue}------ this is found to be of type `String`{/}
- {fg:Blue}15{/} {fg:Blue}│{/}           _ 0 => "Buzz"
-    {fg:Blue}│{/}                  {fg:Blue}------ this is found to be of type `String`{/}
- {fg:Blue}16{/} {fg:Blue}│{/}           _ _ => num
-    {fg:Blue}│{/}                  {fg:Red}^^^ expected `String`, found `Nat`{/}
-    {fg:Blue}│{/}
+    {fg:Blue}│{/}  
     {fg:Blue}={/} expected type `String`
          found type `Nat`
 

--- a/codespan-reporting/tests/snapshots/term__fizz_buzz__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__fizz_buzz__rich_no_color.snap
@@ -5,7 +5,7 @@ expression: TEST_DATA.emit_no_color(&config)
 error[E0308]: `case` clauses have incompatible types
 
    ┌── FizzBuzz.fun:3:15 ───
-   │
+   │  
  3 │   fizz₁ : Nat → String
    │                 ------ expected type `String` found here
  4 │   fizz₁ num = case (mod num 5) (mod num 3) of
@@ -14,37 +14,30 @@ error[E0308]: `case` clauses have incompatible types
  6 │ │     0 _ => "Fizz"
  7 │ │     _ 0 => "Buzz"
  8 │ │     _ _ => num
+   │ │            ^^^ expected `String`, found `Nat`
    │ ╰──────────────' `case` clauses have incompatible types
-   ·
- 8 │       _ _ => num
-   │              ^^^ expected `String`, found `Nat`
-   │
+   │  
    = expected type `String`
         found type `Nat`
 
 error[E0308]: `case` clauses have incompatible types
 
     ┌── FizzBuzz.fun:10:15 ───
-    │
+    │  
  10 │   fizz₂ : Nat → String
     │                 ------ expected type `String` found here
  11 │   fizz₂ num =
  12 │ ╭     case (mod num 5) (mod num 3) of
  13 │ │         0 0 => "FizzBuzz"
+    │ │                ---------- this is found to be of type `String`
  14 │ │         0 _ => "Fizz"
+    │ │                ------ this is found to be of type `String`
  15 │ │         _ 0 => "Buzz"
+    │ │                ------ this is found to be of type `String`
  16 │ │         _ _ => num
+    │ │                ^^^ expected `String`, found `Nat`
     │ ╰──────────────────' `case` clauses have incompatible types
-    ·
- 13 │           0 0 => "FizzBuzz"
-    │                  ---------- this is found to be of type `String`
- 14 │           0 _ => "Fizz"
-    │                  ------ this is found to be of type `String`
- 15 │           _ 0 => "Buzz"
-    │                  ------ this is found to be of type `String`
- 16 │           _ _ => num
-    │                  ^^^ expected `String`, found `Nat`
-    │
+    │  
     = expected type `String`
          found type `Nat`
 

--- a/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_color.snap
@@ -5,28 +5,21 @@ expression: TEST_DATA.emit_color(&config)
 {fg:Red bold bright}error[E0308]{bold bright}: match arms have incompatible types{/}
 
    {fg:Blue}┌──{/} codespan/src/file.rs:1:9 {fg:Blue}───{/}
-   {fg:Blue}│{/}
- {fg:Blue}1{/} {fg:Blue}│{/} {fg:Blue}╭{/}         match line_index.compare(self.last_line_index()) {
- {fg:Blue}2{/} {fg:Blue}│{/} {fg:Blue}│{/}             Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
- {fg:Blue}3{/} {fg:Blue}│{/} {fg:Blue}│{/}             Ordering::Equal => Ok(self.source_span().end()),
- {fg:Blue}4{/} {fg:Blue}│{/} {fg:Blue}│{/}             Ordering::Greater => LineIndexOutOfBoundsError {
- {fg:Blue}5{/} {fg:Blue}│{/} {fg:Blue}│{/}                 given: line_index,
- {fg:Blue}6{/} {fg:Blue}│{/} {fg:Blue}│{/}                 max: self.last_line_index(),
- {fg:Blue}7{/} {fg:Blue}│{/} {fg:Blue}│{/}             },
- {fg:Blue}8{/} {fg:Blue}│{/} {fg:Blue}│{/}         }
-   {fg:Blue}│{/} {fg:Blue}╰{/}{fg:Blue}─────────' `match` arms have incompatible types{/}
-   {fg:Blue}·{/}
- {fg:Blue}2{/} {fg:Blue}│{/}               Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
-   {fg:Blue}│{/}                                 {fg:Blue}--------------------------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`{/}
- {fg:Blue}3{/} {fg:Blue}│{/}               Ordering::Equal => Ok(self.source_span().end()),
-   {fg:Blue}│{/}                                  {fg:Blue}---------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`{/}
- {fg:Blue}4{/} {fg:Blue}│{/}               Ordering::Greater => LineIndexOutOfBoundsError {
-   {fg:Blue}│{/} {fg:Red}╭{/}{fg:Red}──────────────────────────────────^{/}
- {fg:Blue}5{/} {fg:Blue}│{/} {fg:Red}│{/}                 given: line_index,
- {fg:Blue}6{/} {fg:Blue}│{/} {fg:Red}│{/}                 max: self.last_line_index(),
- {fg:Blue}7{/} {fg:Blue}│{/} {fg:Red}│{/}             },
-   {fg:Blue}│{/} {fg:Red}╰{/}{fg:Red}─────────────^ expected enum `Result`, found struct `LineIndexOutOfBoundsError`{/}
-   {fg:Blue}│{/}
+   {fg:Blue}│{/}    
+ {fg:Blue}1{/} {fg:Blue}│{/}   {fg:Blue}╭{/}         match line_index.compare(self.last_line_index()) {
+ {fg:Blue}2{/} {fg:Blue}│{/}   {fg:Blue}│{/}             Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
+   {fg:Blue}│{/}   {fg:Blue}│{/}                               {fg:Blue}--------------------------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`{/}
+ {fg:Blue}3{/} {fg:Blue}│{/}   {fg:Blue}│{/}             Ordering::Equal => Ok(self.source_span().end()),
+   {fg:Blue}│{/}   {fg:Blue}│{/}                                {fg:Blue}---------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`{/}
+ {fg:Blue}4{/} {fg:Blue}│{/}   {fg:Blue}│{/}             Ordering::Greater => LineIndexOutOfBoundsError {
+   {fg:Blue}│{/} {fg:Red}╭{/}{fg:Red}─{/}{fg:Blue}│{/}{fg:Red}──────────────────────────────────^{/}
+ {fg:Blue}5{/} {fg:Blue}│{/} {fg:Red}│{/} {fg:Blue}│{/}                 given: line_index,
+ {fg:Blue}6{/} {fg:Blue}│{/} {fg:Red}│{/} {fg:Blue}│{/}                 max: self.last_line_index(),
+ {fg:Blue}7{/} {fg:Blue}│{/} {fg:Red}│{/} {fg:Blue}│{/}             },
+   {fg:Blue}│{/} {fg:Red}╰{/}{fg:Red}─{/}{fg:Blue}│{/}{fg:Red}─────────────^ expected enum `Result`, found struct `LineIndexOutOfBoundsError`{/}
+ {fg:Blue}8{/} {fg:Blue}│{/}   {fg:Blue}│{/}         }
+   {fg:Blue}│{/}   {fg:Blue}╰{/}{fg:Blue}─────────' `match` arms have incompatible types{/}
+   {fg:Blue}│{/}    
    {fg:Blue}={/} expected type `Result<ByteIndex, LineIndexOutOfBoundsError>`
         found type `LineIndexOutOfBoundsError`
 

--- a/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_color.snap
@@ -1,0 +1,33 @@
+---
+source: codespan-reporting/tests/term.rs
+expression: TEST_DATA.emit_color(&config)
+---
+{fg:Red bold bright}error[E0308]{bold bright}: match arms have incompatible types{/}
+
+   {fg:Blue}┌──{/} codespan/src/file.rs:1:9 {fg:Blue}───{/}
+   {fg:Blue}│{/}
+ {fg:Blue}1{/} {fg:Blue}│{/} {fg:Blue}╭{/}         match line_index.compare(self.last_line_index()) {
+ {fg:Blue}2{/} {fg:Blue}│{/} {fg:Blue}│{/}             Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
+ {fg:Blue}3{/} {fg:Blue}│{/} {fg:Blue}│{/}             Ordering::Equal => Ok(self.source_span().end()),
+ {fg:Blue}4{/} {fg:Blue}│{/} {fg:Blue}│{/}             Ordering::Greater => LineIndexOutOfBoundsError {
+ {fg:Blue}5{/} {fg:Blue}│{/} {fg:Blue}│{/}                 given: line_index,
+ {fg:Blue}6{/} {fg:Blue}│{/} {fg:Blue}│{/}                 max: self.last_line_index(),
+ {fg:Blue}7{/} {fg:Blue}│{/} {fg:Blue}│{/}             },
+ {fg:Blue}8{/} {fg:Blue}│{/} {fg:Blue}│{/}         }
+   {fg:Blue}│{/} {fg:Blue}╰{/}{fg:Blue}─────────' `match` arms have incompatible types{/}
+   {fg:Blue}·{/}
+ {fg:Blue}2{/} {fg:Blue}│{/}               Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
+   {fg:Blue}│{/}                                 {fg:Blue}--------------------------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`{/}
+ {fg:Blue}3{/} {fg:Blue}│{/}               Ordering::Equal => Ok(self.source_span().end()),
+   {fg:Blue}│{/}                                  {fg:Blue}---------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`{/}
+ {fg:Blue}4{/} {fg:Blue}│{/}               Ordering::Greater => LineIndexOutOfBoundsError {
+   {fg:Blue}│{/} {fg:Red}╭{/}{fg:Red}──────────────────────────────────^{/}
+ {fg:Blue}5{/} {fg:Blue}│{/} {fg:Red}│{/}                 given: line_index,
+ {fg:Blue}6{/} {fg:Blue}│{/} {fg:Red}│{/}                 max: self.last_line_index(),
+ {fg:Blue}7{/} {fg:Blue}│{/} {fg:Red}│{/}             },
+   {fg:Blue}│{/} {fg:Red}╰{/}{fg:Red}─────────────^ expected enum `Result`, found struct `LineIndexOutOfBoundsError`{/}
+   {fg:Blue}│{/}
+   {fg:Blue}={/} expected type `Result<ByteIndex, LineIndexOutOfBoundsError>`
+        found type `LineIndexOutOfBoundsError`
+
+

--- a/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_no_color.snap
@@ -5,28 +5,21 @@ expression: TEST_DATA.emit_no_color(&config)
 error[E0308]: match arms have incompatible types
 
    ┌── codespan/src/file.rs:1:9 ───
-   │
- 1 │ ╭         match line_index.compare(self.last_line_index()) {
- 2 │ │             Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
- 3 │ │             Ordering::Equal => Ok(self.source_span().end()),
- 4 │ │             Ordering::Greater => LineIndexOutOfBoundsError {
- 5 │ │                 given: line_index,
- 6 │ │                 max: self.last_line_index(),
- 7 │ │             },
- 8 │ │         }
-   │ ╰─────────' `match` arms have incompatible types
-   ·
- 2 │               Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
-   │                                 --------------------------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
- 3 │               Ordering::Equal => Ok(self.source_span().end()),
-   │                                  ---------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
- 4 │               Ordering::Greater => LineIndexOutOfBoundsError {
-   │ ╭──────────────────────────────────^
- 5 │ │                 given: line_index,
- 6 │ │                 max: self.last_line_index(),
- 7 │ │             },
-   │ ╰─────────────^ expected enum `Result`, found struct `LineIndexOutOfBoundsError`
-   │
+   │    
+ 1 │   ╭         match line_index.compare(self.last_line_index()) {
+ 2 │   │             Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
+   │   │                               --------------------------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
+ 3 │   │             Ordering::Equal => Ok(self.source_span().end()),
+   │   │                                ---------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
+ 4 │   │             Ordering::Greater => LineIndexOutOfBoundsError {
+   │ ╭─│──────────────────────────────────^
+ 5 │ │ │                 given: line_index,
+ 6 │ │ │                 max: self.last_line_index(),
+ 7 │ │ │             },
+   │ ╰─│─────────────^ expected enum `Result`, found struct `LineIndexOutOfBoundsError`
+ 8 │   │         }
+   │   ╰─────────' `match` arms have incompatible types
+   │    
    = expected type `Result<ByteIndex, LineIndexOutOfBoundsError>`
         found type `LineIndexOutOfBoundsError`
 

--- a/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_no_color.snap
@@ -1,0 +1,33 @@
+---
+source: codespan-reporting/tests/term.rs
+expression: TEST_DATA.emit_no_color(&config)
+---
+error[E0308]: match arms have incompatible types
+
+   ┌── codespan/src/file.rs:1:9 ───
+   │
+ 1 │ ╭         match line_index.compare(self.last_line_index()) {
+ 2 │ │             Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
+ 3 │ │             Ordering::Equal => Ok(self.source_span().end()),
+ 4 │ │             Ordering::Greater => LineIndexOutOfBoundsError {
+ 5 │ │                 given: line_index,
+ 6 │ │                 max: self.last_line_index(),
+ 7 │ │             },
+ 8 │ │         }
+   │ ╰─────────' `match` arms have incompatible types
+   ·
+ 2 │               Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
+   │                                 --------------------------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
+ 3 │               Ordering::Equal => Ok(self.source_span().end()),
+   │                                  ---------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
+ 4 │               Ordering::Greater => LineIndexOutOfBoundsError {
+   │ ╭──────────────────────────────────^
+ 5 │ │                 given: line_index,
+ 6 │ │                 max: self.last_line_index(),
+ 7 │ │             },
+   │ ╰─────────────^ expected enum `Result`, found struct `LineIndexOutOfBoundsError`
+   │
+   = expected type `Result<ByteIndex, LineIndexOutOfBoundsError>`
+        found type `LineIndexOutOfBoundsError`
+
+

--- a/codespan-reporting/tests/snapshots/term__multiline_overlapping__short_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multiline_overlapping__short_color.snap
@@ -1,0 +1,6 @@
+---
+source: codespan-reporting/tests/term.rs
+expression: TEST_DATA.emit_color(&config)
+---
+codespan/src/file.rs:4:34: {fg:Red bold bright}error[E0308]{bold bright}: match arms have incompatible types{/}
+

--- a/codespan-reporting/tests/snapshots/term__multiline_overlapping__short_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multiline_overlapping__short_no_color.snap
@@ -1,0 +1,6 @@
+---
+source: codespan-reporting/tests/term.rs
+expression: TEST_DATA.emit_no_color(&config)
+---
+codespan/src/file.rs:4:34: error[E0308]: match arms have incompatible types
+

--- a/codespan-reporting/tests/term.rs
+++ b/codespan-reporting/tests/term.rs
@@ -381,7 +381,7 @@ mod multiline_overlapping {
                     "                max: self.last_line_index(),",
                     "            },",
                     "        }",
-                ].join("\n")
+                ].join("\n"),
             );
 
             let diagnostics = vec![
@@ -398,7 +398,7 @@ mod multiline_overlapping {
                         "
                             expected type `Result<ByteIndex, LineIndexOutOfBoundsError>`
                                found type `LineIndexOutOfBoundsError`
-                        "
+                        ",
                     )]),
             ];
 


### PR DESCRIPTION
This renders overlapping multiline labels on the same lines of source code. This means that the following example:

```
error[E0308]: match arms have incompatible types

   ┌── codespan/src/file.rs:1:9 ───
   │
 1 │ ╭         match line_index.compare(self.last_line_index()) {
 2 │ │             Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
 3 │ │             Ordering::Equal => Ok(self.source_span().end()),
 4 │ │             Ordering::Greater => LineIndexOutOfBoundsError {
 5 │ │                 given: line_index,
 6 │ │                 max: self.last_line_index(),
 7 │ │             },
 8 │ │         }
   │ ╰─────────' `match` arms have incompatible types
   ·
 2 │               Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
   │                                 --------------------------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
 3 │               Ordering::Equal => Ok(self.source_span().end()),
   │                                  ---------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
 4 │               Ordering::Greater => LineIndexOutOfBoundsError {
   │ ╭──────────────────────────────────^
 5 │ │                 given: line_index,
 6 │ │                 max: self.last_line_index(),
 7 │ │             },
   │ ╰─────────────^ expected enum `Result`, found struct `LineIndexOutOfBoundsError`
   │
   = expected type `Result<ByteIndex, LineIndexOutOfBoundsError>`
        found type `LineIndexOutOfBoundsError`
```

…is now rendered as:

```
error[E0308]: match arms have incompatible types

   ┌── codespan/src/file.rs:1:9 ───
   │
 1 │   ╭         match line_index.compare(self.last_line_index()) {
 2 │   │             Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
   │   │                               --------------------------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
 3 │   │             Ordering::Equal => Ok(self.source_span().end()),
   │   │                                ---------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
 4 │   │             Ordering::Greater => LineIndexOutOfBoundsError {
   │ ╭─│──────────────────────────────────^
 5 │ │ │                 given: line_index,
 6 │ │ │                 max: self.last_line_index(),
 7 │ │ │             },
   │ ╰─│─────────────^ expected enum `Result`, found struct `LineIndexOutOfBoundsError`
 8 │   │         }
   │   ╰─────────' `match` arms have incompatible types
   │
   = expected type `Result<ByteIndex, LineIndexOutOfBoundsError>`
        found type `LineIndexOutOfBoundsError`
```

Closes #100