### PR TITLE
Reduce the prominence of the locus in snippets

### DIFF
--- a/codespan-reporting/assets/readme_preview.svg
+++ b/codespan-reporting/assets/readme_preview.svg
@@ -53,7 +53,7 @@
     <div xmlns="http://www.w3.org/1999/xhtml">
       <pre><span class="fg red bold bright">error[E0308]</span><span class="bold bright">: `case` clauses have incompatible types</span>
 
-    <span class="fg blue">┌──</span> FizzBuzz.fun:10:15 <span class="fg blue">───</span>
+    <span class="fg blue">┌─</span> FizzBuzz.fun:10:15
     <span class="fg blue">│</span>  
  <span class="fg blue">10</span> <span class="fg blue">│</span>   fizz₂ : Nat → String
     <span class="fg blue">│</span>                 <span class="fg blue">------ expected type `String` found here</span>

--- a/codespan-reporting/src/term/config.rs
+++ b/codespan-reporting/src/term/config.rs
@@ -91,7 +91,7 @@ pub enum DisplayStyle {
     /// ```text
     /// error[E0001]: unexpected type in `+` application
     ///
-    ///    ┌── test:2:9 ───
+    ///    ┌─ test:2:9
     ///    │
     ///  2 │ (+ test "")
     ///    │         ^^ expected `Int` but found `String`

--- a/codespan-reporting/src/term/renderer.rs
+++ b/codespan-reporting/src/term/renderer.rs
@@ -72,7 +72,7 @@ type Underline = (LabelStyle, VerticalBound);
 ///                  ┌────────────────────────────────────────────────────────────────────────────
 ///        header ── │ error[0001]: oh noes, a cupcake has occurred!
 ///         empty ── │
-/// snippet start ── │    ┌── test:9:0 ───
+/// snippet start ── │    ┌─ test:9:0
 /// snippet empty ── │    │
 ///  snippet line ── │  9 │   ╭ Cupcake ipsum dolor. Sit amet marshmallow topping cheesecake
 ///  snippet line ── │ 10 │   │ muffin. Halvah croissant candy canes bonbon candy. Apple pie jelly
@@ -100,6 +100,7 @@ type Underline = (LabelStyle, VerticalBound);
 ///                  │      blah blah
 ///  snippet note ── │    = blah blah blah
 ///                  │      blah blah
+///         empty ── │
 /// ```
 ///
 /// Filler text from http://www.cupcakeipsum.com
@@ -194,23 +195,19 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     /// Top left border and locus.
     ///
     /// ```text
-    /// ┌── test:2:9 ───
+    /// ┌─ test:2:9
     /// ```
     pub fn render_snippet_start(&mut self, outer_padding: usize, locus: &Locus) -> io::Result<()> {
         self.outer_gutter(outer_padding)?;
 
         self.set_color(&self.styles().source_border)?;
         write!(self, "{}", self.chars().source_border_top_left)?;
-        write!(self, "{0}{0}", self.chars().source_border_top)?;
+        write!(self, "{0}", self.chars().source_border_top)?;
         self.reset()?;
 
         write!(self, " ")?;
         self.snippet_locus(&locus)?;
-        write!(self, " ")?;
 
-        self.set_color(&self.styles().source_border)?;
-        write!(self, "{0}{0}{0}", self.chars().source_border_top)?;
-        self.reset()?;
         write!(self, "\n")?;
 
         Ok(())

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -248,8 +248,7 @@ where
         // Source snippets
         //
         // ```text
-        //
-        //   ┌── test:2:9 ───
+        //   ┌─ test:2:9
         //   │
         // 2 │ (+ test "")
         //   │         ^^ expected `Int` but found `String`
@@ -262,7 +261,7 @@ where
             // Top left border and locus.
             //
             // ```text
-            // ┌── test:2:9 ───
+            // ┌─ test:2:9
             // ```
             if !labeled_file.lines.is_empty() {
                 renderer.render_snippet_start(

--- a/codespan-reporting/tests/snapshots/term__empty_spans__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__empty_spans__rich_color.snap
@@ -4,7 +4,7 @@ expression: TEST_DATA.emit_color(&config)
 ---
 {fg:Green bold bright}note{bold bright}: middle{/}
 
-   {fg:Blue}┌──{/} hello:1:7 {fg:Blue}───{/}
+   {fg:Blue}┌─{/} hello:1:7
    {fg:Blue}│{/}
  {fg:Blue}1{/} {fg:Blue}│{/} Hello world!
    {fg:Blue}│{/}       {fg:Green}^ middle{/}
@@ -12,7 +12,7 @@ expression: TEST_DATA.emit_color(&config)
 
 {fg:Green bold bright}note{bold bright}: end of line{/}
 
-   {fg:Blue}┌──{/} hello:1:13 {fg:Blue}───{/}
+   {fg:Blue}┌─{/} hello:1:13
    {fg:Blue}│{/}
  {fg:Blue}1{/} {fg:Blue}│{/} Hello world!
    {fg:Blue}│{/}             {fg:Green}^ end of line{/}
@@ -20,7 +20,7 @@ expression: TEST_DATA.emit_color(&config)
 
 {fg:Green bold bright}note{bold bright}: end of file{/}
 
-   {fg:Blue}┌──{/} hello:2:11 {fg:Blue}───{/}
+   {fg:Blue}┌─{/} hello:2:11
    {fg:Blue}│{/}
  {fg:Blue}2{/} {fg:Blue}│{/} Bye world!
    {fg:Blue}│{/}           {fg:Green}^ end of file{/}

--- a/codespan-reporting/tests/snapshots/term__empty_spans__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__empty_spans__rich_no_color.snap
@@ -4,7 +4,7 @@ expression: TEST_DATA.emit_no_color(&config)
 ---
 note: middle
 
-   ┌── hello:1:7 ───
+   ┌─ hello:1:7
    │
  1 │ Hello world!
    │       ^ middle
@@ -12,7 +12,7 @@ note: middle
 
 note: end of line
 
-   ┌── hello:1:13 ───
+   ┌─ hello:1:13
    │
  1 │ Hello world!
    │             ^ end of line
@@ -20,7 +20,7 @@ note: end of line
 
 note: end of file
 
-   ┌── hello:2:11 ───
+   ┌─ hello:2:11
    │
  2 │ Bye world!
    │           ^ end of file

--- a/codespan-reporting/tests/snapshots/term__fizz_buzz__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__fizz_buzz__rich_color.snap
@@ -4,7 +4,7 @@ expression: TEST_DATA.emit_color(&config)
 ---
 {fg:Red bold bright}error[E0308]{bold bright}: `case` clauses have incompatible types{/}
 
-   {fg:Blue}┌──{/} FizzBuzz.fun:3:15 {fg:Blue}───{/}
+   {fg:Blue}┌─{/} FizzBuzz.fun:3:15
    {fg:Blue}│{/}  
  {fg:Blue}3{/} {fg:Blue}│{/}   fizz₁ : Nat → String
    {fg:Blue}│{/}                 {fg:Blue}------ expected type `String` found here{/}
@@ -22,7 +22,7 @@ expression: TEST_DATA.emit_color(&config)
 
 {fg:Red bold bright}error[E0308]{bold bright}: `case` clauses have incompatible types{/}
 
-    {fg:Blue}┌──{/} FizzBuzz.fun:10:15 {fg:Blue}───{/}
+    {fg:Blue}┌─{/} FizzBuzz.fun:10:15
     {fg:Blue}│{/}  
  {fg:Blue}10{/} {fg:Blue}│{/}   fizz₂ : Nat → String
     {fg:Blue}│{/}                 {fg:Blue}------ expected type `String` found here{/}

--- a/codespan-reporting/tests/snapshots/term__fizz_buzz__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__fizz_buzz__rich_no_color.snap
@@ -4,7 +4,7 @@ expression: TEST_DATA.emit_no_color(&config)
 ---
 error[E0308]: `case` clauses have incompatible types
 
-   ┌── FizzBuzz.fun:3:15 ───
+   ┌─ FizzBuzz.fun:3:15
    │  
  3 │   fizz₁ : Nat → String
    │                 ------ expected type `String` found here
@@ -22,7 +22,7 @@ error[E0308]: `case` clauses have incompatible types
 
 error[E0308]: `case` clauses have incompatible types
 
-    ┌── FizzBuzz.fun:10:15 ───
+    ┌─ FizzBuzz.fun:10:15
     │  
  10 │   fizz₂ : Nat → String
     │                 ------ expected type `String` found here

--- a/codespan-reporting/tests/snapshots/term__multifile__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multifile__rich_color.snap
@@ -4,7 +4,7 @@ expression: TEST_DATA.emit_color(&config)
 ---
 {fg:Red bold bright}error{bold bright}: unknown builtin: `NATRAL`{/}
 
-   {fg:Blue}┌──{/} Data/Nat.fun:7:13 {fg:Blue}───{/}
+   {fg:Blue}┌─{/} Data/Nat.fun:7:13
    {fg:Blue}│{/}
  {fg:Blue}7{/} {fg:Blue}│{/} {-# BUILTIN NATRAL Nat #-}
    {fg:Blue}│{/}             {fg:Red}^^^^^^ unknown builtin{/}
@@ -13,7 +13,7 @@ expression: TEST_DATA.emit_color(&config)
 
 {fg:Yellow bold bright}warning{bold bright}: unused parameter pattern: `n₂`{/}
 
-    {fg:Blue}┌──{/} Data/Nat.fun:17:16 {fg:Blue}───{/}
+    {fg:Blue}┌─{/} Data/Nat.fun:17:16
     {fg:Blue}│{/}
  {fg:Blue}17{/} {fg:Blue}│{/} zero    - succ n₂ = zero
     {fg:Blue}│{/}                {fg:Yellow}^^ unused parameter{/}
@@ -22,12 +22,12 @@ expression: TEST_DATA.emit_color(&config)
 
 {fg:Red bold bright}error[E0001]{bold bright}: unexpected type in application of `_+_`{/}
 
-    {fg:Blue}┌──{/} Test.fun:4:11 {fg:Blue}───{/}
+    {fg:Blue}┌─{/} Test.fun:4:11
     {fg:Blue}│{/}
  {fg:Blue} 4{/} {fg:Blue}│{/} _ = 123 + "hello"
     {fg:Blue}│{/}           {fg:Red}^^^^^^^ expected `Nat`, found `String`{/}
     {fg:Blue}│{/}
-    {fg:Blue}┌──{/} Data/Nat.fun:11:1 {fg:Blue}───{/}
+    {fg:Blue}┌─{/} Data/Nat.fun:11:1
     {fg:Blue}│{/}
  {fg:Blue}11{/} {fg:Blue}│{/} _+_ : Nat → Nat → Nat
     {fg:Blue}│{/} {fg:Blue}--------------------- based on the definition of `_+_`{/}

--- a/codespan-reporting/tests/snapshots/term__multifile__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multifile__rich_no_color.snap
@@ -4,7 +4,7 @@ expression: TEST_DATA.emit_no_color(&config)
 ---
 error: unknown builtin: `NATRAL`
 
-   ┌── Data/Nat.fun:7:13 ───
+   ┌─ Data/Nat.fun:7:13
    │
  7 │ {-# BUILTIN NATRAL Nat #-}
    │             ^^^^^^ unknown builtin
@@ -13,7 +13,7 @@ error: unknown builtin: `NATRAL`
 
 warning: unused parameter pattern: `n₂`
 
-    ┌── Data/Nat.fun:17:16 ───
+    ┌─ Data/Nat.fun:17:16
     │
  17 │ zero    - succ n₂ = zero
     │                ^^ unused parameter
@@ -22,12 +22,12 @@ warning: unused parameter pattern: `n₂`
 
 error[E0001]: unexpected type in application of `_+_`
 
-    ┌── Test.fun:4:11 ───
+    ┌─ Test.fun:4:11
     │
   4 │ _ = 123 + "hello"
     │           ^^^^^^^ expected `Nat`, found `String`
     │
-    ┌── Data/Nat.fun:11:1 ───
+    ┌─ Data/Nat.fun:11:1
     │
  11 │ _+_ : Nat → Nat → Nat
     │ --------------------- based on the definition of `_+_`

--- a/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_color.snap
@@ -4,7 +4,7 @@ expression: TEST_DATA.emit_color(&config)
 ---
 {fg:Red bold bright}error[E0308]{bold bright}: match arms have incompatible types{/}
 
-   {fg:Blue}┌──{/} codespan/src/file.rs:1:9 {fg:Blue}───{/}
+   {fg:Blue}┌─{/} codespan/src/file.rs:1:9
    {fg:Blue}│{/}    
  {fg:Blue}1{/} {fg:Blue}│{/}   {fg:Blue}╭{/}         match line_index.compare(self.last_line_index()) {
  {fg:Blue}2{/} {fg:Blue}│{/}   {fg:Blue}│{/}             Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),

--- a/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_no_color.snap
@@ -4,7 +4,7 @@ expression: TEST_DATA.emit_no_color(&config)
 ---
 error[E0308]: match arms have incompatible types
 
-   ┌── codespan/src/file.rs:1:9 ───
+   ┌─ codespan/src/file.rs:1:9
    │    
  1 │   ╭         match line_index.compare(self.last_line_index()) {
  2 │   │             Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),

--- a/codespan-reporting/tests/snapshots/term__one_line__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__one_line__rich_color.snap
@@ -4,7 +4,7 @@ expression: TEST_DATA.emit_color(&config)
 ---
 {fg:Red bold bright}error[E0499]{bold bright}: cannot borrow `v` as mutable more than once at a time{/}
 
-   {fg:Blue}┌──{/} one_line.rs:3:5 {fg:Blue}───{/}
+   {fg:Blue}┌─{/} one_line.rs:3:5
    {fg:Blue}│{/}
  {fg:Blue}3{/} {fg:Blue}│{/}     v.push(v.pop().unwrap());
    {fg:Blue}│{/}     {fg:Blue}- first borrow later used by call{/}

--- a/codespan-reporting/tests/snapshots/term__one_line__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__one_line__rich_no_color.snap
@@ -4,7 +4,7 @@ expression: TEST_DATA.emit_no_color(&config)
 ---
 error[E0499]: cannot borrow `v` as mutable more than once at a time
 
-   ┌── one_line.rs:3:5 ───
+   ┌─ one_line.rs:3:5
    │
  3 │     v.push(v.pop().unwrap());
    │     - first borrow later used by call

--- a/codespan-reporting/tests/snapshots/term__tabbed__tab_width_3_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__tabbed__tab_width_3_no_color.snap
@@ -4,7 +4,7 @@ expression: TEST_DATA.emit_no_color(&config)
 ---
 warning: unknown weapon `DogJaw`
 
-   ┌── tabbed:3:11 ───
+   ┌─ tabbed:3:11
    │
  3 │       Weapon: DogJaw
    │               ^^^^^^ the weapon
@@ -12,7 +12,7 @@ warning: unknown weapon `DogJaw`
 
 warning: unknown condition `attack-cooldown`
 
-   ┌── tabbed:4:23 ───
+   ┌─ tabbed:4:23
    │
  4 │       ReloadingCondition:   attack-cooldown
    │                             ^^^^^^^^^^^^^^^ the condition
@@ -20,7 +20,7 @@ warning: unknown condition `attack-cooldown`
 
 warning: unknown field `Foo`
 
-   ┌── tabbed:5:2 ───
+   ┌─ tabbed:5:2
    │
  5 │    Foo: Bar
    │    ^^^ the field

--- a/codespan-reporting/tests/snapshots/term__tabbed__tab_width_6_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__tabbed__tab_width_6_no_color.snap
@@ -4,7 +4,7 @@ expression: TEST_DATA.emit_no_color(&config)
 ---
 warning: unknown weapon `DogJaw`
 
-   ┌── tabbed:3:11 ───
+   ┌─ tabbed:3:11
    │
  3 │             Weapon: DogJaw
    │                     ^^^^^^ the weapon
@@ -12,7 +12,7 @@ warning: unknown weapon `DogJaw`
 
 warning: unknown condition `attack-cooldown`
 
-   ┌── tabbed:4:23 ───
+   ┌─ tabbed:4:23
    │
  4 │             ReloadingCondition:      attack-cooldown
    │                                      ^^^^^^^^^^^^^^^ the condition
@@ -20,7 +20,7 @@ warning: unknown condition `attack-cooldown`
 
 warning: unknown field `Foo`
 
-   ┌── tabbed:5:2 ───
+   ┌─ tabbed:5:2
    │
  5 │       Foo: Bar
    │       ^^^ the field

--- a/codespan-reporting/tests/snapshots/term__tabbed__tab_width_default_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__tabbed__tab_width_default_no_color.snap
@@ -4,7 +4,7 @@ expression: TEST_DATA.emit_no_color(&config)
 ---
 warning: unknown weapon `DogJaw`
 
-   ┌── tabbed:3:11 ───
+   ┌─ tabbed:3:11
    │
  3 │         Weapon: DogJaw
    │                 ^^^^^^ the weapon
@@ -12,7 +12,7 @@ warning: unknown weapon `DogJaw`
 
 warning: unknown condition `attack-cooldown`
 
-   ┌── tabbed:4:23 ───
+   ┌─ tabbed:4:23
    │
  4 │         ReloadingCondition:    attack-cooldown
    │                                ^^^^^^^^^^^^^^^ the condition
@@ -20,7 +20,7 @@ warning: unknown condition `attack-cooldown`
 
 warning: unknown field `Foo`
 
-   ┌── tabbed:5:2 ───
+   ┌─ tabbed:5:2
    │
  5 │     Foo: Bar
    │     ^^^ the field

--- a/codespan-reporting/tests/snapshots/term__unicode__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__unicode__rich_no_color.snap
@@ -4,7 +4,7 @@ expression: TEST_DATA.emit_no_color(&config)
 ---
 error[E0703]: invalid ABI: found `路濫狼á́́`
 
-   ┌── unicode.rs:1:8 ───
+   ┌─ unicode.rs:1:8
    │
  1 │ extern "路濫狼á́́" fn foo() {}
    │        ^^^^^^^^^ invalid ABI


### PR DESCRIPTION
The current locus is a little noisey, and detracts from the diagnostic message, which is what we want users to be focused on.

For example, before this change we rendered:
```
error: unknown builtin: `NATRAL`

   ┌── Data/Nat.fun:7:13 ───
   │
 7 │ {-# BUILTIN NATRAL Nat #-}
   │             ^^^^^^ unknown builtin
   │
   = there is a builtin with a similar name: `NATURAL`
```
…we now render the following:
```
error: unknown builtin: `NATRAL`

   ┌─ Data/Nat.fun:7:13
   │
 7 │ {-# BUILTIN NATRAL Nat #-}
   │             ^^^^^^ unknown builtin
   │
   = there is a builtin with a similar name: `NATURAL`
```