### PR TITLE
Add padding to the source range if it doesn't end on a char boundary.

### DIFF
--- a/codespan-reporting/tests/snapshots/term__unicode_spans__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__unicode_spans__rich_no_color.snap
@@ -1,0 +1,16 @@
+---
+source: codespan-reporting/tests/term.rs
+expression: TEST_DATA.emit_no_color(&config)
+---
+error[E01]: cow may not jump during new moon.
+
+   ┌─ moon_jump.rs:1:1
+   │
+ 1 │ 🐄🌑🐄🌒🐄🌓🐄🌔🐄🌕🐄🌖🐄🌗🐄🌘🐄
+   │   ^^ Invalid jump
+   │   -- Cow range does not start at boundary.
+   │   ------ Cow does not start or end at boundary.
+   │     -- Cow range does not end at boundary.
+   │
+
+

--- a/codespan-reporting/tests/snapshots/term__unicode_spans__short_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__unicode_spans__short_no_color.snap
@@ -1,0 +1,6 @@
+---
+source: codespan-reporting/tests/term.rs
+expression: TEST_DATA.emit_no_color(&config)
+---
+moon_jump.rs:1:1: error[E01]: cow may not jump during new moon.
+


### PR DESCRIPTION
I'm not sure if this is the best, but this avoids a panic when given a bad location range ending in the middle of a unicode character.

This fixes all the panics I see in #224 when running [json-pop](https://github.com/ratmice/json-pop) through the invalid cases at [JSONTestSuite](https://github.com/nst/JSONTestSuite/tree/master/test_parsing)