### PR TITLE
Tighten up spacing around source snippets

### DIFF
--- a/codespan-reporting/assets/readme_preview.svg
+++ b/codespan-reporting/assets/readme_preview.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 882 350" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 882 335" xmlns="http://www.w3.org/2000/svg">
   <style>
     /* https://github.com/aaron-williamson/base16-alacritty/blob/master/colors/base16-tomorrow-night-256.yml */
     pre {
@@ -49,28 +49,27 @@
     pre .bg.white.bright    { background-color: #ffffff; }
   </style>
 
-  <foreignObject x="0" y="0" width="882" height="350">
+  <foreignObject x="0" y="0" width="882" height="335">
     <div xmlns="http://www.w3.org/1999/xhtml">
       <pre><span class="fg red bold bright">error[E0308]</span><span class="bold bright">: `case` clauses have incompatible types</span>
-
-    <span class="fg blue">┌─</span> FizzBuzz.fun:10:15
-    <span class="fg blue">│</span>  
- <span class="fg blue">10</span> <span class="fg blue">│</span>   fizz₂ : Nat → String
-    <span class="fg blue">│</span>                 <span class="fg blue">------ expected type `String` found here</span>
- <span class="fg blue">11</span> <span class="fg blue">│</span>   fizz₂ num =
- <span class="fg blue">12</span> <span class="fg blue">│</span> <span class="fg blue">╭</span>     case (mod num 5) (mod num 3) of
- <span class="fg blue">13</span> <span class="fg blue">│</span> <span class="fg blue">│</span>         0 0 =&gt; "FizzBuzz"
-    <span class="fg blue">│</span> <span class="fg blue">│</span>                <span class="fg blue">---------- this is found to be of type `String`</span>
- <span class="fg blue">14</span> <span class="fg blue">│</span> <span class="fg blue">│</span>         0 _ =&gt; "Fizz"
-    <span class="fg blue">│</span> <span class="fg blue">│</span>                <span class="fg blue">------ this is found to be of type `String`</span>
- <span class="fg blue">15</span> <span class="fg blue">│</span> <span class="fg blue">│</span>         _ 0 =&gt; "Buzz"
-    <span class="fg blue">│</span> <span class="fg blue">│</span>                <span class="fg blue">------ this is found to be of type `String`</span>
- <span class="fg blue">16</span> <span class="fg blue">│</span> <span class="fg blue">│</span>         _ _ =&gt; num
-    <span class="fg blue">│</span> <span class="fg blue">│</span>                <span class="fg red">^^^ expected `String`, found `Nat`</span>
-    <span class="fg blue">│</span> <span class="fg blue">╰</span><span class="fg blue">──────────────────' `case` clauses have incompatible types</span>
-    <span class="fg blue">│</span>  
-    <span class="fg blue">=</span> expected type `String`
-         found type `Nat`
+   <span class="fg blue">┌─</span> FizzBuzz.fun:10:15
+   <span class="fg blue">│</span>  
+<span class="fg blue">10</span> <span class="fg blue">│</span>   fizz₂ : Nat → String
+   <span class="fg blue">│</span>                 <span class="fg blue">------ expected type `String` found here</span>
+<span class="fg blue">11</span> <span class="fg blue">│</span>   fizz₂ num =
+<span class="fg blue">12</span> <span class="fg blue">│</span> <span class="fg blue">╭</span>     case (mod num 5) (mod num 3) of
+<span class="fg blue">13</span> <span class="fg blue">│</span> <span class="fg blue">│</span>         0 0 =&gt; "FizzBuzz"
+   <span class="fg blue">│</span> <span class="fg blue">│</span>                <span class="fg blue">---------- this is found to be of type `String`</span>
+<span class="fg blue">14</span> <span class="fg blue">│</span> <span class="fg blue">│</span>         0 _ =&gt; "Fizz"
+   <span class="fg blue">│</span> <span class="fg blue">│</span>                <span class="fg blue">------ this is found to be of type `String`</span>
+<span class="fg blue">15</span> <span class="fg blue">│</span> <span class="fg blue">│</span>         _ 0 =&gt; "Buzz"
+   <span class="fg blue">│</span> <span class="fg blue">│</span>                <span class="fg blue">------ this is found to be of type `String`</span>
+<span class="fg blue">16</span> <span class="fg blue">│</span> <span class="fg blue">│</span>         _ _ =&gt; num
+   <span class="fg blue">│</span> <span class="fg blue">│</span>                <span class="fg red">^^^ expected `String`, found `Nat`</span>
+   <span class="fg blue">│</span> <span class="fg blue">╰</span><span class="fg blue">──────────────────' `case` clauses have incompatible types</span>
+   <span class="fg blue">│</span>  
+   <span class="fg blue">=</span> expected type `String`
+        found type `Nat`
 
 </pre>
     </div>

--- a/codespan-reporting/examples/term.rs
+++ b/codespan-reporting/examples/term.rs
@@ -116,7 +116,13 @@ fn main() -> anyhow::Result<()> {
                 Label::primary(file_id2, 37..44).with_message("expected `Nat`, found `String`"),
                 Label::secondary(file_id1, 130..155)
                     .with_message("based on the definition of `_+_`"),
-            ]),
+            ])
+            .with_notes(vec![unindent::unindent(
+                "
+                    expected type `Nat`
+                       found type `String`
+                ",
+            )]),
         // Incompatible match clause error
         Diagnostic::error()
             .with_message("`case` clauses have incompatible types")

--- a/codespan-reporting/src/term/config.rs
+++ b/codespan-reporting/src/term/config.rs
@@ -90,14 +90,13 @@ pub enum DisplayStyle {
     ///
     /// ```text
     /// error[E0001]: unexpected type in `+` application
-    ///
-    ///    ┌─ test:2:9
-    ///    │
-    ///  2 │ (+ test "")
-    ///    │         ^^ expected `Int` but found `String`
-    ///    │
-    ///    = expected type `Int`
-    ///         found type `String`
+    ///   ┌─ test:2:9
+    ///   │
+    /// 2 │ (+ test "")
+    ///   │         ^^ expected `Int` but found `String`
+    ///   │
+    ///   = expected type `Int`
+    ///        found type `String`
     ///
     /// error[E0002]: Bad config found
     ///

--- a/codespan-reporting/src/term/renderer.rs
+++ b/codespan-reporting/src/term/renderer.rs
@@ -232,7 +232,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         // Write source line
         //
         // ```text
-        //  10 │   │ muffin. Halvah croissant candy canes bonbon candy. Apple pie jelly
+        // 10 │   │ muffin. Halvah croissant candy canes bonbon candy. Apple pie jelly
         // ```
         {
             // Write outer gutter (with line number) and border
@@ -419,7 +419,6 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
 
     /// The outer gutter of a source line.
     fn outer_gutter(&mut self, outer_padding: usize) -> io::Result<()> {
-        write!(self, " ")?;
         write!(self, "{space: >width$}", space = "", width = outer_padding,)?;
         write!(self, " ")?;
         Ok(())
@@ -427,7 +426,6 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
 
     /// The outer gutter of a source line, with line number.
     fn outer_gutter_number(&mut self, line_number: usize, outer_padding: usize) -> io::Result<()> {
-        write!(self, " ")?;
         self.set_color(&self.styles().line_number)?;
         write!(
             self,

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -244,9 +244,6 @@ where
             self.diagnostic.code.as_ref().map(String::as_str),
             self.diagnostic.message.as_str(),
         )?;
-        if !labeled_files.is_empty() {
-            renderer.render_empty()?;
-        }
 
         // Source snippets
         //

--- a/codespan-reporting/tests/snapshots/term__empty_ranges__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__empty_ranges__rich_color.snap
@@ -3,27 +3,24 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_color(&config)
 ---
 {fg:Green bold bright}note{bold bright}: middle{/}
-
-   {fg:Blue}┌─{/} hello:1:7
-   {fg:Blue}│{/}
- {fg:Blue}1{/} {fg:Blue}│{/} Hello world!
-   {fg:Blue}│{/}       {fg:Green}^ middle{/}
-   {fg:Blue}│{/}
+  {fg:Blue}┌─{/} hello:1:7
+  {fg:Blue}│{/}
+{fg:Blue}1{/} {fg:Blue}│{/} Hello world!
+  {fg:Blue}│{/}       {fg:Green}^ middle{/}
+  {fg:Blue}│{/}
 
 {fg:Green bold bright}note{bold bright}: end of line{/}
-
-   {fg:Blue}┌─{/} hello:1:13
-   {fg:Blue}│{/}
- {fg:Blue}1{/} {fg:Blue}│{/} Hello world!
-   {fg:Blue}│{/}             {fg:Green}^ end of line{/}
-   {fg:Blue}│{/}
+  {fg:Blue}┌─{/} hello:1:13
+  {fg:Blue}│{/}
+{fg:Blue}1{/} {fg:Blue}│{/} Hello world!
+  {fg:Blue}│{/}             {fg:Green}^ end of line{/}
+  {fg:Blue}│{/}
 
 {fg:Green bold bright}note{bold bright}: end of file{/}
-
-   {fg:Blue}┌─{/} hello:2:11
-   {fg:Blue}│{/}
- {fg:Blue}2{/} {fg:Blue}│{/} Bye world!
-   {fg:Blue}│{/}           {fg:Green}^ end of file{/}
-   {fg:Blue}│{/}
+  {fg:Blue}┌─{/} hello:2:11
+  {fg:Blue}│{/}
+{fg:Blue}2{/} {fg:Blue}│{/} Bye world!
+  {fg:Blue}│{/}           {fg:Green}^ end of file{/}
+  {fg:Blue}│{/}
 
 

--- a/codespan-reporting/tests/snapshots/term__empty_ranges__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__empty_ranges__rich_no_color.snap
@@ -3,27 +3,24 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_no_color(&config)
 ---
 note: middle
-
-   ┌─ hello:1:7
-   │
- 1 │ Hello world!
-   │       ^ middle
-   │
+  ┌─ hello:1:7
+  │
+1 │ Hello world!
+  │       ^ middle
+  │
 
 note: end of line
-
-   ┌─ hello:1:13
-   │
- 1 │ Hello world!
-   │             ^ end of line
-   │
+  ┌─ hello:1:13
+  │
+1 │ Hello world!
+  │             ^ end of line
+  │
 
 note: end of file
-
-   ┌─ hello:2:11
-   │
- 2 │ Bye world!
-   │           ^ end of file
-   │
+  ┌─ hello:2:11
+  │
+2 │ Bye world!
+  │           ^ end of file
+  │
 
 

--- a/codespan-reporting/tests/snapshots/term__fizz_buzz__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__fizz_buzz__rich_color.snap
@@ -3,42 +3,40 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_color(&config)
 ---
 {fg:Red bold bright}error[E0308]{bold bright}: `case` clauses have incompatible types{/}
+  {fg:Blue}┌─{/} FizzBuzz.fun:3:15
+  {fg:Blue}│{/}  
+{fg:Blue}3{/} {fg:Blue}│{/}   fizz₁ : Nat → String
+  {fg:Blue}│{/}                 {fg:Blue}------ expected type `String` found here{/}
+{fg:Blue}4{/} {fg:Blue}│{/}   fizz₁ num = case (mod num 5) (mod num 3) of
+  {fg:Blue}│{/} {fg:Blue}╭{/}{fg:Blue}─────────────'{/}
+{fg:Blue}5{/} {fg:Blue}│{/} {fg:Blue}│{/}     0 0 => "FizzBuzz"
+{fg:Blue}6{/} {fg:Blue}│{/} {fg:Blue}│{/}     0 _ => "Fizz"
+{fg:Blue}7{/} {fg:Blue}│{/} {fg:Blue}│{/}     _ 0 => "Buzz"
+{fg:Blue}8{/} {fg:Blue}│{/} {fg:Blue}│{/}     _ _ => num
+  {fg:Blue}│{/} {fg:Blue}│{/}            {fg:Red}^^^ expected `String`, found `Nat`{/}
+  {fg:Blue}│{/} {fg:Blue}╰{/}{fg:Blue}──────────────' `case` clauses have incompatible types{/}
+  {fg:Blue}│{/}  
+  {fg:Blue}={/} expected type `String`
+       found type `Nat`
 
-   {fg:Blue}┌─{/} FizzBuzz.fun:3:15
+{fg:Red bold bright}error[E0308]{bold bright}: `case` clauses have incompatible types{/}
+   {fg:Blue}┌─{/} FizzBuzz.fun:10:15
    {fg:Blue}│{/}  
- {fg:Blue}3{/} {fg:Blue}│{/}   fizz₁ : Nat → String
+{fg:Blue}10{/} {fg:Blue}│{/}   fizz₂ : Nat → String
    {fg:Blue}│{/}                 {fg:Blue}------ expected type `String` found here{/}
- {fg:Blue}4{/} {fg:Blue}│{/}   fizz₁ num = case (mod num 5) (mod num 3) of
-   {fg:Blue}│{/} {fg:Blue}╭{/}{fg:Blue}─────────────'{/}
- {fg:Blue}5{/} {fg:Blue}│{/} {fg:Blue}│{/}     0 0 => "FizzBuzz"
- {fg:Blue}6{/} {fg:Blue}│{/} {fg:Blue}│{/}     0 _ => "Fizz"
- {fg:Blue}7{/} {fg:Blue}│{/} {fg:Blue}│{/}     _ 0 => "Buzz"
- {fg:Blue}8{/} {fg:Blue}│{/} {fg:Blue}│{/}     _ _ => num
-   {fg:Blue}│{/} {fg:Blue}│{/}            {fg:Red}^^^ expected `String`, found `Nat`{/}
-   {fg:Blue}│{/} {fg:Blue}╰{/}{fg:Blue}──────────────' `case` clauses have incompatible types{/}
+{fg:Blue}11{/} {fg:Blue}│{/}   fizz₂ num =
+{fg:Blue}12{/} {fg:Blue}│{/} {fg:Blue}╭{/}     case (mod num 5) (mod num 3) of
+{fg:Blue}13{/} {fg:Blue}│{/} {fg:Blue}│{/}         0 0 => "FizzBuzz"
+   {fg:Blue}│{/} {fg:Blue}│{/}                {fg:Blue}---------- this is found to be of type `String`{/}
+{fg:Blue}14{/} {fg:Blue}│{/} {fg:Blue}│{/}         0 _ => "Fizz"
+   {fg:Blue}│{/} {fg:Blue}│{/}                {fg:Blue}------ this is found to be of type `String`{/}
+{fg:Blue}15{/} {fg:Blue}│{/} {fg:Blue}│{/}         _ 0 => "Buzz"
+   {fg:Blue}│{/} {fg:Blue}│{/}                {fg:Blue}------ this is found to be of type `String`{/}
+{fg:Blue}16{/} {fg:Blue}│{/} {fg:Blue}│{/}         _ _ => num
+   {fg:Blue}│{/} {fg:Blue}│{/}                {fg:Red}^^^ expected `String`, found `Nat`{/}
+   {fg:Blue}│{/} {fg:Blue}╰{/}{fg:Blue}──────────────────' `case` clauses have incompatible types{/}
    {fg:Blue}│{/}  
    {fg:Blue}={/} expected type `String`
         found type `Nat`
-
-{fg:Red bold bright}error[E0308]{bold bright}: `case` clauses have incompatible types{/}
-
-    {fg:Blue}┌─{/} FizzBuzz.fun:10:15
-    {fg:Blue}│{/}  
- {fg:Blue}10{/} {fg:Blue}│{/}   fizz₂ : Nat → String
-    {fg:Blue}│{/}                 {fg:Blue}------ expected type `String` found here{/}
- {fg:Blue}11{/} {fg:Blue}│{/}   fizz₂ num =
- {fg:Blue}12{/} {fg:Blue}│{/} {fg:Blue}╭{/}     case (mod num 5) (mod num 3) of
- {fg:Blue}13{/} {fg:Blue}│{/} {fg:Blue}│{/}         0 0 => "FizzBuzz"
-    {fg:Blue}│{/} {fg:Blue}│{/}                {fg:Blue}---------- this is found to be of type `String`{/}
- {fg:Blue}14{/} {fg:Blue}│{/} {fg:Blue}│{/}         0 _ => "Fizz"
-    {fg:Blue}│{/} {fg:Blue}│{/}                {fg:Blue}------ this is found to be of type `String`{/}
- {fg:Blue}15{/} {fg:Blue}│{/} {fg:Blue}│{/}         _ 0 => "Buzz"
-    {fg:Blue}│{/} {fg:Blue}│{/}                {fg:Blue}------ this is found to be of type `String`{/}
- {fg:Blue}16{/} {fg:Blue}│{/} {fg:Blue}│{/}         _ _ => num
-    {fg:Blue}│{/} {fg:Blue}│{/}                {fg:Red}^^^ expected `String`, found `Nat`{/}
-    {fg:Blue}│{/} {fg:Blue}╰{/}{fg:Blue}──────────────────' `case` clauses have incompatible types{/}
-    {fg:Blue}│{/}  
-    {fg:Blue}={/} expected type `String`
-         found type `Nat`
 
 

--- a/codespan-reporting/tests/snapshots/term__fizz_buzz__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__fizz_buzz__rich_no_color.snap
@@ -3,42 +3,40 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_no_color(&config)
 ---
 error[E0308]: `case` clauses have incompatible types
+  ┌─ FizzBuzz.fun:3:15
+  │  
+3 │   fizz₁ : Nat → String
+  │                 ------ expected type `String` found here
+4 │   fizz₁ num = case (mod num 5) (mod num 3) of
+  │ ╭─────────────'
+5 │ │     0 0 => "FizzBuzz"
+6 │ │     0 _ => "Fizz"
+7 │ │     _ 0 => "Buzz"
+8 │ │     _ _ => num
+  │ │            ^^^ expected `String`, found `Nat`
+  │ ╰──────────────' `case` clauses have incompatible types
+  │  
+  = expected type `String`
+       found type `Nat`
 
-   ┌─ FizzBuzz.fun:3:15
+error[E0308]: `case` clauses have incompatible types
+   ┌─ FizzBuzz.fun:10:15
    │  
- 3 │   fizz₁ : Nat → String
+10 │   fizz₂ : Nat → String
    │                 ------ expected type `String` found here
- 4 │   fizz₁ num = case (mod num 5) (mod num 3) of
-   │ ╭─────────────'
- 5 │ │     0 0 => "FizzBuzz"
- 6 │ │     0 _ => "Fizz"
- 7 │ │     _ 0 => "Buzz"
- 8 │ │     _ _ => num
-   │ │            ^^^ expected `String`, found `Nat`
-   │ ╰──────────────' `case` clauses have incompatible types
+11 │   fizz₂ num =
+12 │ ╭     case (mod num 5) (mod num 3) of
+13 │ │         0 0 => "FizzBuzz"
+   │ │                ---------- this is found to be of type `String`
+14 │ │         0 _ => "Fizz"
+   │ │                ------ this is found to be of type `String`
+15 │ │         _ 0 => "Buzz"
+   │ │                ------ this is found to be of type `String`
+16 │ │         _ _ => num
+   │ │                ^^^ expected `String`, found `Nat`
+   │ ╰──────────────────' `case` clauses have incompatible types
    │  
    = expected type `String`
         found type `Nat`
-
-error[E0308]: `case` clauses have incompatible types
-
-    ┌─ FizzBuzz.fun:10:15
-    │  
- 10 │   fizz₂ : Nat → String
-    │                 ------ expected type `String` found here
- 11 │   fizz₂ num =
- 12 │ ╭     case (mod num 5) (mod num 3) of
- 13 │ │         0 0 => "FizzBuzz"
-    │ │                ---------- this is found to be of type `String`
- 14 │ │         0 _ => "Fizz"
-    │ │                ------ this is found to be of type `String`
- 15 │ │         _ 0 => "Buzz"
-    │ │                ------ this is found to be of type `String`
- 16 │ │         _ _ => num
-    │ │                ^^^ expected `String`, found `Nat`
-    │ ╰──────────────────' `case` clauses have incompatible types
-    │  
-    = expected type `String`
-         found type `Nat`
 
 

--- a/codespan-reporting/tests/snapshots/term__message_and_notes__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__message_and_notes__rich_color.snap
@@ -3,15 +3,15 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_color(&config)
 ---
 {fg:Red bold bright}error{bold bright}: a message{/}
-  {fg:Blue}={/} a note
+ {fg:Blue}={/} a note
 
 {fg:Yellow bold bright}warning{bold bright}: a message{/}
-  {fg:Blue}={/} a note
+ {fg:Blue}={/} a note
 
 {fg:Green bold bright}note{bold bright}: a message{/}
-  {fg:Blue}={/} a note
+ {fg:Blue}={/} a note
 
 {fg:Cyan bold bright}help{bold bright}: a message{/}
-  {fg:Blue}={/} a note
+ {fg:Blue}={/} a note
 
 

--- a/codespan-reporting/tests/snapshots/term__message_and_notes__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__message_and_notes__rich_no_color.snap
@@ -3,15 +3,15 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_no_color(&config)
 ---
 error: a message
-  = a note
+ = a note
 
 warning: a message
-  = a note
+ = a note
 
 note: a message
-  = a note
+ = a note
 
 help: a message
-  = a note
+ = a note
 
 

--- a/codespan-reporting/tests/snapshots/term__multifile__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multifile__rich_color.snap
@@ -32,5 +32,7 @@ expression: TEST_DATA.emit_color(&config)
  {fg:Blue}11{/} {fg:Blue}│{/} _+_ : Nat → Nat → Nat
     {fg:Blue}│{/} {fg:Blue}--------------------- based on the definition of `_+_`{/}
     {fg:Blue}│{/}
+    {fg:Blue}={/} expected type `Nat`
+         found type `String`
 
 

--- a/codespan-reporting/tests/snapshots/term__multifile__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multifile__rich_color.snap
@@ -3,36 +3,33 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_color(&config)
 ---
 {fg:Red bold bright}error{bold bright}: unknown builtin: `NATRAL`{/}
-
-   {fg:Blue}┌─{/} Data/Nat.fun:7:13
-   {fg:Blue}│{/}
- {fg:Blue}7{/} {fg:Blue}│{/} {-# BUILTIN NATRAL Nat #-}
-   {fg:Blue}│{/}             {fg:Red}^^^^^^ unknown builtin{/}
-   {fg:Blue}│{/}
-   {fg:Blue}={/} there is a builtin with a similar name: `NATURAL`
+  {fg:Blue}┌─{/} Data/Nat.fun:7:13
+  {fg:Blue}│{/}
+{fg:Blue}7{/} {fg:Blue}│{/} {-# BUILTIN NATRAL Nat #-}
+  {fg:Blue}│{/}             {fg:Red}^^^^^^ unknown builtin{/}
+  {fg:Blue}│{/}
+  {fg:Blue}={/} there is a builtin with a similar name: `NATURAL`
 
 {fg:Yellow bold bright}warning{bold bright}: unused parameter pattern: `n₂`{/}
-
-    {fg:Blue}┌─{/} Data/Nat.fun:17:16
-    {fg:Blue}│{/}
- {fg:Blue}17{/} {fg:Blue}│{/} zero    - succ n₂ = zero
-    {fg:Blue}│{/}                {fg:Yellow}^^ unused parameter{/}
-    {fg:Blue}│{/}
-    {fg:Blue}={/} consider using a wildcard pattern: `_`
+   {fg:Blue}┌─{/} Data/Nat.fun:17:16
+   {fg:Blue}│{/}
+{fg:Blue}17{/} {fg:Blue}│{/} zero    - succ n₂ = zero
+   {fg:Blue}│{/}                {fg:Yellow}^^ unused parameter{/}
+   {fg:Blue}│{/}
+   {fg:Blue}={/} consider using a wildcard pattern: `_`
 
 {fg:Red bold bright}error[E0001]{bold bright}: unexpected type in application of `_+_`{/}
-
-    {fg:Blue}┌─{/} Test.fun:4:11
-    {fg:Blue}│{/}
- {fg:Blue} 4{/} {fg:Blue}│{/} _ = 123 + "hello"
-    {fg:Blue}│{/}           {fg:Red}^^^^^^^ expected `Nat`, found `String`{/}
-    {fg:Blue}│{/}
-    {fg:Blue}┌─{/} Data/Nat.fun:11:1
-    {fg:Blue}│{/}
- {fg:Blue}11{/} {fg:Blue}│{/} _+_ : Nat → Nat → Nat
-    {fg:Blue}│{/} {fg:Blue}--------------------- based on the definition of `_+_`{/}
-    {fg:Blue}│{/}
-    {fg:Blue}={/} expected type `Nat`
-         found type `String`
+   {fg:Blue}┌─{/} Test.fun:4:11
+   {fg:Blue}│{/}
+{fg:Blue} 4{/} {fg:Blue}│{/} _ = 123 + "hello"
+   {fg:Blue}│{/}           {fg:Red}^^^^^^^ expected `Nat`, found `String`{/}
+   {fg:Blue}│{/}
+   {fg:Blue}┌─{/} Data/Nat.fun:11:1
+   {fg:Blue}│{/}
+{fg:Blue}11{/} {fg:Blue}│{/} _+_ : Nat → Nat → Nat
+   {fg:Blue}│{/} {fg:Blue}--------------------- based on the definition of `_+_`{/}
+   {fg:Blue}│{/}
+   {fg:Blue}={/} expected type `Nat`
+        found type `String`
 
 

--- a/codespan-reporting/tests/snapshots/term__multifile__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multifile__rich_no_color.snap
@@ -3,36 +3,33 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_no_color(&config)
 ---
 error: unknown builtin: `NATRAL`
-
-   ┌─ Data/Nat.fun:7:13
-   │
- 7 │ {-# BUILTIN NATRAL Nat #-}
-   │             ^^^^^^ unknown builtin
-   │
-   = there is a builtin with a similar name: `NATURAL`
+  ┌─ Data/Nat.fun:7:13
+  │
+7 │ {-# BUILTIN NATRAL Nat #-}
+  │             ^^^^^^ unknown builtin
+  │
+  = there is a builtin with a similar name: `NATURAL`
 
 warning: unused parameter pattern: `n₂`
-
-    ┌─ Data/Nat.fun:17:16
-    │
- 17 │ zero    - succ n₂ = zero
-    │                ^^ unused parameter
-    │
-    = consider using a wildcard pattern: `_`
+   ┌─ Data/Nat.fun:17:16
+   │
+17 │ zero    - succ n₂ = zero
+   │                ^^ unused parameter
+   │
+   = consider using a wildcard pattern: `_`
 
 error[E0001]: unexpected type in application of `_+_`
-
-    ┌─ Test.fun:4:11
-    │
-  4 │ _ = 123 + "hello"
-    │           ^^^^^^^ expected `Nat`, found `String`
-    │
-    ┌─ Data/Nat.fun:11:1
-    │
- 11 │ _+_ : Nat → Nat → Nat
-    │ --------------------- based on the definition of `_+_`
-    │
-    = expected type `Nat`
-         found type `String`
+   ┌─ Test.fun:4:11
+   │
+ 4 │ _ = 123 + "hello"
+   │           ^^^^^^^ expected `Nat`, found `String`
+   │
+   ┌─ Data/Nat.fun:11:1
+   │
+11 │ _+_ : Nat → Nat → Nat
+   │ --------------------- based on the definition of `_+_`
+   │
+   = expected type `Nat`
+        found type `String`
 
 

--- a/codespan-reporting/tests/snapshots/term__multifile__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multifile__rich_no_color.snap
@@ -32,5 +32,7 @@ error[E0001]: unexpected type in application of `_+_`
  11 │ _+_ : Nat → Nat → Nat
     │ --------------------- based on the definition of `_+_`
     │
+    = expected type `Nat`
+         found type `String`
 
 

--- a/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_color.snap
@@ -3,24 +3,23 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_color(&config)
 ---
 {fg:Red bold bright}error[E0308]{bold bright}: match arms have incompatible types{/}
-
-   {fg:Blue}┌─{/} codespan/src/file.rs:1:9
-   {fg:Blue}│{/}    
- {fg:Blue}1{/} {fg:Blue}│{/}   {fg:Blue}╭{/}         match line_index.compare(self.last_line_index()) {
- {fg:Blue}2{/} {fg:Blue}│{/}   {fg:Blue}│{/}             Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
-   {fg:Blue}│{/}   {fg:Blue}│{/}                               {fg:Blue}--------------------------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`{/}
- {fg:Blue}3{/} {fg:Blue}│{/}   {fg:Blue}│{/}             Ordering::Equal => Ok(self.source_span().end()),
-   {fg:Blue}│{/}   {fg:Blue}│{/}                                {fg:Blue}---------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`{/}
- {fg:Blue}4{/} {fg:Blue}│{/}   {fg:Blue}│{/}             Ordering::Greater => LineIndexOutOfBoundsError {
-   {fg:Blue}│{/} {fg:Red}╭{/}{fg:Red}─{/}{fg:Blue}│{/}{fg:Red}──────────────────────────────────^{/}
- {fg:Blue}5{/} {fg:Blue}│{/} {fg:Red}│{/} {fg:Blue}│{/}                 given: line_index,
- {fg:Blue}6{/} {fg:Blue}│{/} {fg:Red}│{/} {fg:Blue}│{/}                 max: self.last_line_index(),
- {fg:Blue}7{/} {fg:Blue}│{/} {fg:Red}│{/} {fg:Blue}│{/}             },
-   {fg:Blue}│{/} {fg:Red}╰{/}{fg:Red}─{/}{fg:Blue}│{/}{fg:Red}─────────────^ expected enum `Result`, found struct `LineIndexOutOfBoundsError`{/}
- {fg:Blue}8{/} {fg:Blue}│{/}   {fg:Blue}│{/}         }
-   {fg:Blue}│{/}   {fg:Blue}╰{/}{fg:Blue}─────────' `match` arms have incompatible types{/}
-   {fg:Blue}│{/}    
-   {fg:Blue}={/} expected type `Result<ByteIndex, LineIndexOutOfBoundsError>`
-        found type `LineIndexOutOfBoundsError`
+  {fg:Blue}┌─{/} codespan/src/file.rs:1:9
+  {fg:Blue}│{/}    
+{fg:Blue}1{/} {fg:Blue}│{/}   {fg:Blue}╭{/}         match line_index.compare(self.last_line_index()) {
+{fg:Blue}2{/} {fg:Blue}│{/}   {fg:Blue}│{/}             Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
+  {fg:Blue}│{/}   {fg:Blue}│{/}                               {fg:Blue}--------------------------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`{/}
+{fg:Blue}3{/} {fg:Blue}│{/}   {fg:Blue}│{/}             Ordering::Equal => Ok(self.source_span().end()),
+  {fg:Blue}│{/}   {fg:Blue}│{/}                                {fg:Blue}---------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`{/}
+{fg:Blue}4{/} {fg:Blue}│{/}   {fg:Blue}│{/}             Ordering::Greater => LineIndexOutOfBoundsError {
+  {fg:Blue}│{/} {fg:Red}╭{/}{fg:Red}─{/}{fg:Blue}│{/}{fg:Red}──────────────────────────────────^{/}
+{fg:Blue}5{/} {fg:Blue}│{/} {fg:Red}│{/} {fg:Blue}│{/}                 given: line_index,
+{fg:Blue}6{/} {fg:Blue}│{/} {fg:Red}│{/} {fg:Blue}│{/}                 max: self.last_line_index(),
+{fg:Blue}7{/} {fg:Blue}│{/} {fg:Red}│{/} {fg:Blue}│{/}             },
+  {fg:Blue}│{/} {fg:Red}╰{/}{fg:Red}─{/}{fg:Blue}│{/}{fg:Red}─────────────^ expected enum `Result`, found struct `LineIndexOutOfBoundsError`{/}
+{fg:Blue}8{/} {fg:Blue}│{/}   {fg:Blue}│{/}         }
+  {fg:Blue}│{/}   {fg:Blue}╰{/}{fg:Blue}─────────' `match` arms have incompatible types{/}
+  {fg:Blue}│{/}    
+  {fg:Blue}={/} expected type `Result<ByteIndex, LineIndexOutOfBoundsError>`
+       found type `LineIndexOutOfBoundsError`
 
 

--- a/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__multiline_overlapping__rich_no_color.snap
@@ -3,24 +3,23 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_no_color(&config)
 ---
 error[E0308]: match arms have incompatible types
-
-   ┌─ codespan/src/file.rs:1:9
-   │    
- 1 │   ╭         match line_index.compare(self.last_line_index()) {
- 2 │   │             Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
-   │   │                               --------------------------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
- 3 │   │             Ordering::Equal => Ok(self.source_span().end()),
-   │   │                                ---------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
- 4 │   │             Ordering::Greater => LineIndexOutOfBoundsError {
-   │ ╭─│──────────────────────────────────^
- 5 │ │ │                 given: line_index,
- 6 │ │ │                 max: self.last_line_index(),
- 7 │ │ │             },
-   │ ╰─│─────────────^ expected enum `Result`, found struct `LineIndexOutOfBoundsError`
- 8 │   │         }
-   │   ╰─────────' `match` arms have incompatible types
-   │    
-   = expected type `Result<ByteIndex, LineIndexOutOfBoundsError>`
-        found type `LineIndexOutOfBoundsError`
+  ┌─ codespan/src/file.rs:1:9
+  │    
+1 │   ╭         match line_index.compare(self.last_line_index()) {
+2 │   │             Ordering::Less => Ok(self.line_starts()[line_index.to_usize()]),
+  │   │                               --------------------------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
+3 │   │             Ordering::Equal => Ok(self.source_span().end()),
+  │   │                                ---------------------------- this is found to be of type `Result<ByteIndex, LineIndexOutOfBoundsError>`
+4 │   │             Ordering::Greater => LineIndexOutOfBoundsError {
+  │ ╭─│──────────────────────────────────^
+5 │ │ │                 given: line_index,
+6 │ │ │                 max: self.last_line_index(),
+7 │ │ │             },
+  │ ╰─│─────────────^ expected enum `Result`, found struct `LineIndexOutOfBoundsError`
+8 │   │         }
+  │   ╰─────────' `match` arms have incompatible types
+  │    
+  = expected type `Result<ByteIndex, LineIndexOutOfBoundsError>`
+       found type `LineIndexOutOfBoundsError`
 
 

--- a/codespan-reporting/tests/snapshots/term__one_line__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__one_line__rich_color.snap
@@ -3,16 +3,15 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_color(&config)
 ---
 {fg:Red bold bright}error[E0499]{bold bright}: cannot borrow `v` as mutable more than once at a time{/}
-
-   {fg:Blue}┌─{/} one_line.rs:3:5
-   {fg:Blue}│{/}
- {fg:Blue}3{/} {fg:Blue}│{/}     v.push(v.pop().unwrap());
-   {fg:Blue}│{/}     {fg:Blue}- first borrow later used by call{/}
-   {fg:Blue}│{/}       {fg:Blue}---- first mutable borrow occurs here{/}
-   {fg:Blue}│{/}            {fg:Red}^ second mutable borrow occurs here{/}
-   {fg:Blue}│{/}
+  {fg:Blue}┌─{/} one_line.rs:3:5
+  {fg:Blue}│{/}
+{fg:Blue}3{/} {fg:Blue}│{/}     v.push(v.pop().unwrap());
+  {fg:Blue}│{/}     {fg:Blue}- first borrow later used by call{/}
+  {fg:Blue}│{/}       {fg:Blue}---- first mutable borrow occurs here{/}
+  {fg:Blue}│{/}            {fg:Red}^ second mutable borrow occurs here{/}
+  {fg:Blue}│{/}
 
 {fg:Red bold bright}error{bold bright}: aborting due to previous error{/}
-  {fg:Blue}={/} For more information about this error, try `rustc --explain E0499`.
+ {fg:Blue}={/} For more information about this error, try `rustc --explain E0499`.
 
 

--- a/codespan-reporting/tests/snapshots/term__one_line__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__one_line__rich_no_color.snap
@@ -3,16 +3,15 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_no_color(&config)
 ---
 error[E0499]: cannot borrow `v` as mutable more than once at a time
-
-   ┌─ one_line.rs:3:5
-   │
- 3 │     v.push(v.pop().unwrap());
-   │     - first borrow later used by call
-   │       ---- first mutable borrow occurs here
-   │            ^ second mutable borrow occurs here
-   │
+  ┌─ one_line.rs:3:5
+  │
+3 │     v.push(v.pop().unwrap());
+  │     - first borrow later used by call
+  │       ---- first mutable borrow occurs here
+  │            ^ second mutable borrow occurs here
+  │
 
 error: aborting due to previous error
-  = For more information about this error, try `rustc --explain E0499`.
+ = For more information about this error, try `rustc --explain E0499`.
 
 

--- a/codespan-reporting/tests/snapshots/term__same_ranges__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__same_ranges__rich_color.snap
@@ -3,12 +3,11 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_color(&config)
 ---
 {fg:Red bold bright}error{bold bright}: Unexpected token{/}
-
-   {fg:Blue}┌─{/} same_range:1:5
-   {fg:Blue}│{/}
- {fg:Blue}1{/} {fg:Blue}│{/} ::S { }
-   {fg:Blue}│{/}     {fg:Red}^ Unexpected '{'{/}
-   {fg:Blue}│{/}     {fg:Blue}- Expected '('{/}
-   {fg:Blue}│{/}
+  {fg:Blue}┌─{/} same_range:1:5
+  {fg:Blue}│{/}
+{fg:Blue}1{/} {fg:Blue}│{/} ::S { }
+  {fg:Blue}│{/}     {fg:Red}^ Unexpected '{'{/}
+  {fg:Blue}│{/}     {fg:Blue}- Expected '('{/}
+  {fg:Blue}│{/}
 
 

--- a/codespan-reporting/tests/snapshots/term__same_ranges__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__same_ranges__rich_no_color.snap
@@ -3,12 +3,11 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_no_color(&config)
 ---
 error: Unexpected token
-
-   ┌─ same_range:1:5
-   │
- 1 │ ::S { }
-   │     ^ Unexpected '{'
-   │     - Expected '('
-   │
+  ┌─ same_range:1:5
+  │
+1 │ ::S { }
+  │     ^ Unexpected '{'
+  │     - Expected '('
+  │
 
 

--- a/codespan-reporting/tests/snapshots/term__tabbed__tab_width_3_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__tabbed__tab_width_3_no_color.snap
@@ -3,27 +3,24 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_no_color(&config)
 ---
 warning: unknown weapon `DogJaw`
-
-   ┌─ tabbed:3:11
-   │
- 3 │       Weapon: DogJaw
-   │               ^^^^^^ the weapon
-   │
+  ┌─ tabbed:3:11
+  │
+3 │       Weapon: DogJaw
+  │               ^^^^^^ the weapon
+  │
 
 warning: unknown condition `attack-cooldown`
-
-   ┌─ tabbed:4:23
-   │
- 4 │       ReloadingCondition:   attack-cooldown
-   │                             ^^^^^^^^^^^^^^^ the condition
-   │
+  ┌─ tabbed:4:23
+  │
+4 │       ReloadingCondition:   attack-cooldown
+  │                             ^^^^^^^^^^^^^^^ the condition
+  │
 
 warning: unknown field `Foo`
-
-   ┌─ tabbed:5:2
-   │
- 5 │    Foo: Bar
-   │    ^^^ the field
-   │
+  ┌─ tabbed:5:2
+  │
+5 │    Foo: Bar
+  │    ^^^ the field
+  │
 
 

--- a/codespan-reporting/tests/snapshots/term__tabbed__tab_width_6_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__tabbed__tab_width_6_no_color.snap
@@ -3,27 +3,24 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_no_color(&config)
 ---
 warning: unknown weapon `DogJaw`
-
-   ┌─ tabbed:3:11
-   │
- 3 │             Weapon: DogJaw
-   │                     ^^^^^^ the weapon
-   │
+  ┌─ tabbed:3:11
+  │
+3 │             Weapon: DogJaw
+  │                     ^^^^^^ the weapon
+  │
 
 warning: unknown condition `attack-cooldown`
-
-   ┌─ tabbed:4:23
-   │
- 4 │             ReloadingCondition:      attack-cooldown
-   │                                      ^^^^^^^^^^^^^^^ the condition
-   │
+  ┌─ tabbed:4:23
+  │
+4 │             ReloadingCondition:      attack-cooldown
+  │                                      ^^^^^^^^^^^^^^^ the condition
+  │
 
 warning: unknown field `Foo`
-
-   ┌─ tabbed:5:2
-   │
- 5 │       Foo: Bar
-   │       ^^^ the field
-   │
+  ┌─ tabbed:5:2
+  │
+5 │       Foo: Bar
+  │       ^^^ the field
+  │
 
 

--- a/codespan-reporting/tests/snapshots/term__tabbed__tab_width_default_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__tabbed__tab_width_default_no_color.snap
@@ -3,27 +3,24 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_no_color(&config)
 ---
 warning: unknown weapon `DogJaw`
-
-   ┌─ tabbed:3:11
-   │
- 3 │         Weapon: DogJaw
-   │                 ^^^^^^ the weapon
-   │
+  ┌─ tabbed:3:11
+  │
+3 │         Weapon: DogJaw
+  │                 ^^^^^^ the weapon
+  │
 
 warning: unknown condition `attack-cooldown`
-
-   ┌─ tabbed:4:23
-   │
- 4 │         ReloadingCondition:    attack-cooldown
-   │                                ^^^^^^^^^^^^^^^ the condition
-   │
+  ┌─ tabbed:4:23
+  │
+4 │         ReloadingCondition:    attack-cooldown
+  │                                ^^^^^^^^^^^^^^^ the condition
+  │
 
 warning: unknown field `Foo`
-
-   ┌─ tabbed:5:2
-   │
- 5 │     Foo: Bar
-   │     ^^^ the field
-   │
+  ┌─ tabbed:5:2
+  │
+5 │     Foo: Bar
+  │     ^^^ the field
+  │
 
 

--- a/codespan-reporting/tests/snapshots/term__unicode__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__unicode__rich_no_color.snap
@@ -3,35 +3,34 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_no_color(&config)
 ---
 error[E0703]: invalid ABI: found `路濫狼á́́`
-
-   ┌─ unicode.rs:1:8
-   │
- 1 │ extern "路濫狼á́́" fn foo() {}
-   │        ^^^^^^^^^ invalid ABI
-   │
-   = valid ABIs:
-       - aapcs
-       - amdgpu-kernel
-       - C
-       - cdecl
-       - efiapi
-       - fastcall
-       - msp430-interrupt
-       - platform-intrinsic
-       - ptx-kernel
-       - Rust
-       - rust-call
-       - rust-intrinsic
-       - stdcall
-       - system
-       - sysv64
-       - thiscall
-       - unadjusted
-       - vectorcall
-       - win64
-       - x86-interrupt
+  ┌─ unicode.rs:1:8
+  │
+1 │ extern "路濫狼á́́" fn foo() {}
+  │        ^^^^^^^^^ invalid ABI
+  │
+  = valid ABIs:
+      - aapcs
+      - amdgpu-kernel
+      - C
+      - cdecl
+      - efiapi
+      - fastcall
+      - msp430-interrupt
+      - platform-intrinsic
+      - ptx-kernel
+      - Rust
+      - rust-call
+      - rust-intrinsic
+      - stdcall
+      - system
+      - sysv64
+      - thiscall
+      - unadjusted
+      - vectorcall
+      - win64
+      - x86-interrupt
 
 error: aborting due to previous error
-  = For more information about this error, try `rustc --explain E0703`.
+ = For more information about this error, try `rustc --explain E0703`.
 
 

--- a/codespan-reporting/tests/snapshots/term__unicode_spans__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__unicode_spans__rich_no_color.snap
@@ -3,14 +3,13 @@ source: codespan-reporting/tests/term.rs
 expression: TEST_DATA.emit_no_color(&config)
 ---
 error[E01]: cow may not jump during new moon.
-
-   ┌─ moon_jump.rs:1:1
-   │
- 1 │ 🐄🌑🐄🌒🐄🌓🐄🌔🐄🌕🐄🌖🐄🌗🐄🌘🐄
-   │   ^^ Invalid jump
-   │   -- Cow range does not start at boundary.
-   │   ------ Cow does not start or end at boundary.
-   │     -- Cow range does not end at boundary.
-   │
+  ┌─ moon_jump.rs:1:1
+  │
+1 │ 🐄🌑🐄🌒🐄🌓🐄🌔🐄🌕🐄🌖🐄🌗🐄🌘🐄
+  │   ^^ Invalid jump
+  │   -- Cow range does not start at boundary.
+  │   ------ Cow does not start or end at boundary.
+  │     -- Cow range does not end at boundary.
+  │
 
 

--- a/codespan-reporting/tests/term.rs
+++ b/codespan-reporting/tests/term.rs
@@ -301,7 +301,13 @@ mod multifile {
                     .with_labels(vec![
                         Label::primary(file_id2, 37..44).with_message("expected `Nat`, found `String`"),
                         Label::secondary(file_id1, 130..155).with_message("based on the definition of `_+_`"),
-                    ]),
+                    ])
+                    .with_notes(vec![unindent::unindent(
+                        "
+                            expected type `Nat`
+                               found type `String`
+                        ",
+                    )]),
             ];
 
             TestData { files, diagnostics }


### PR DESCRIPTION
This eliminates the spacing between the title and the locus, and the outer spacing to the left of the source numbers.

Originally we would render this:

```
error: unknown builtin: `NATRAL`

   ┌─ Data/Nat.fun:7:13
   │
 7 │ {-# BUILTIN NATRAL Nat #-}
   │             ^^^^^^ unknown builtin
   │
   = there is a builtin with a similar name: `NATURAL`

```

And now we render this:

```
error: unknown builtin: `NATRAL`
  ┌─ Data/Nat.fun:7:13
  │
7 │ {-# BUILTIN NATRAL Nat #-}
  │             ^^^^^^ unknown builtin
  │
  = there is a builtin with a similar name: `NATURAL`

```

This is an alternative to PR #226.