### PR TITLE
Tighten diagnostic spacing when notes are missing

### DIFF
--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -254,7 +254,8 @@ where
         //   │         ^^ expected `Int` but found `String`
         //   │
         // ```
-        for labeled_file in labeled_files {
+        let mut labeled_files = labeled_files.into_iter().peekable();
+        while let Some(labeled_file) = labeled_files.next() {
             let source = files.source(labeled_file.file_id).unwrap();
             let source = source.as_ref();
 
@@ -330,12 +331,22 @@ where
                     }
                 }
             }
-            renderer.render_snippet_empty(
-                outer_padding,
-                self.diagnostic.severity,
-                labeled_file.num_multi_labels,
-                &current_labels,
-            )?;
+
+            // Check to see if we should render a trailing border after the
+            // final line of the snippet.
+            if labeled_files.peek().is_none() && self.diagnostic.notes.is_empty() {
+                // We don't render a border if we are at the final newline
+                // without trailing notes, because it would end up looking too
+                // spaced-out in combination with the final new line.
+            } else {
+                // Render the trailing snippet border.
+                renderer.render_snippet_empty(
+                    outer_padding,
+                    self.diagnostic.severity,
+                    labeled_file.num_multi_labels,
+                    &current_labels,
+                )?;
+            }
         }
 
         // Additional notes

--- a/codespan-reporting/tests/snapshots/term__empty_ranges__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__empty_ranges__rich_color.snap
@@ -7,20 +7,17 @@ expression: TEST_DATA.emit_color(&config)
   {fg:Blue}│{/}
 {fg:Blue}1{/} {fg:Blue}│{/} Hello world!
   {fg:Blue}│{/}       {fg:Green}^ middle{/}
-  {fg:Blue}│{/}
 
 {fg:Green bold bright}note{bold bright}: end of line{/}
   {fg:Blue}┌─{/} hello:1:13
   {fg:Blue}│{/}
 {fg:Blue}1{/} {fg:Blue}│{/} Hello world!
   {fg:Blue}│{/}             {fg:Green}^ end of line{/}
-  {fg:Blue}│{/}
 
 {fg:Green bold bright}note{bold bright}: end of file{/}
   {fg:Blue}┌─{/} hello:2:11
   {fg:Blue}│{/}
 {fg:Blue}2{/} {fg:Blue}│{/} Bye world!
   {fg:Blue}│{/}           {fg:Green}^ end of file{/}
-  {fg:Blue}│{/}
 
 

--- a/codespan-reporting/tests/snapshots/term__empty_ranges__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__empty_ranges__rich_no_color.snap
@@ -7,20 +7,17 @@ note: middle
   │
 1 │ Hello world!
   │       ^ middle
-  │
 
 note: end of line
   ┌─ hello:1:13
   │
 1 │ Hello world!
   │             ^ end of line
-  │
 
 note: end of file
   ┌─ hello:2:11
   │
 2 │ Bye world!
   │           ^ end of file
-  │
 
 

--- a/codespan-reporting/tests/snapshots/term__one_line__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__one_line__rich_color.snap
@@ -9,7 +9,6 @@ expression: TEST_DATA.emit_color(&config)
   {fg:Blue}│{/}     {fg:Blue}- first borrow later used by call{/}
   {fg:Blue}│{/}       {fg:Blue}---- first mutable borrow occurs here{/}
   {fg:Blue}│{/}            {fg:Red}^ second mutable borrow occurs here{/}
-  {fg:Blue}│{/}
 
 {fg:Red bold bright}error{bold bright}: aborting due to previous error{/}
  {fg:Blue}={/} For more information about this error, try `rustc --explain E0499`.

--- a/codespan-reporting/tests/snapshots/term__one_line__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__one_line__rich_no_color.snap
@@ -9,7 +9,6 @@ error[E0499]: cannot borrow `v` as mutable more than once at a time
   │     - first borrow later used by call
   │       ---- first mutable borrow occurs here
   │            ^ second mutable borrow occurs here
-  │
 
 error: aborting due to previous error
  = For more information about this error, try `rustc --explain E0499`.

--- a/codespan-reporting/tests/snapshots/term__same_ranges__rich_color.snap
+++ b/codespan-reporting/tests/snapshots/term__same_ranges__rich_color.snap
@@ -8,6 +8,5 @@ expression: TEST_DATA.emit_color(&config)
 {fg:Blue}1{/} {fg:Blue}│{/} ::S { }
   {fg:Blue}│{/}     {fg:Red}^ Unexpected '{'{/}
   {fg:Blue}│{/}     {fg:Blue}- Expected '('{/}
-  {fg:Blue}│{/}
 
 

--- a/codespan-reporting/tests/snapshots/term__same_ranges__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__same_ranges__rich_no_color.snap
@@ -8,6 +8,5 @@ error: Unexpected token
 1 │ ::S { }
   │     ^ Unexpected '{'
   │     - Expected '('
-  │
 
 

--- a/codespan-reporting/tests/snapshots/term__tabbed__tab_width_3_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__tabbed__tab_width_3_no_color.snap
@@ -7,20 +7,17 @@ warning: unknown weapon `DogJaw`
   │
 3 │       Weapon: DogJaw
   │               ^^^^^^ the weapon
-  │
 
 warning: unknown condition `attack-cooldown`
   ┌─ tabbed:4:23
   │
 4 │       ReloadingCondition:   attack-cooldown
   │                             ^^^^^^^^^^^^^^^ the condition
-  │
 
 warning: unknown field `Foo`
   ┌─ tabbed:5:2
   │
 5 │    Foo: Bar
   │    ^^^ the field
-  │
 
 

--- a/codespan-reporting/tests/snapshots/term__tabbed__tab_width_6_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__tabbed__tab_width_6_no_color.snap
@@ -7,20 +7,17 @@ warning: unknown weapon `DogJaw`
   │
 3 │             Weapon: DogJaw
   │                     ^^^^^^ the weapon
-  │
 
 warning: unknown condition `attack-cooldown`
   ┌─ tabbed:4:23
   │
 4 │             ReloadingCondition:      attack-cooldown
   │                                      ^^^^^^^^^^^^^^^ the condition
-  │
 
 warning: unknown field `Foo`
   ┌─ tabbed:5:2
   │
 5 │       Foo: Bar
   │       ^^^ the field
-  │
 
 

--- a/codespan-reporting/tests/snapshots/term__tabbed__tab_width_default_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__tabbed__tab_width_default_no_color.snap
@@ -7,20 +7,17 @@ warning: unknown weapon `DogJaw`
   │
 3 │         Weapon: DogJaw
   │                 ^^^^^^ the weapon
-  │
 
 warning: unknown condition `attack-cooldown`
   ┌─ tabbed:4:23
   │
 4 │         ReloadingCondition:    attack-cooldown
   │                                ^^^^^^^^^^^^^^^ the condition
-  │
 
 warning: unknown field `Foo`
   ┌─ tabbed:5:2
   │
 5 │     Foo: Bar
   │     ^^^ the field
-  │
 
 

--- a/codespan-reporting/tests/snapshots/term__unicode_spans__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__unicode_spans__rich_no_color.snap
@@ -10,6 +10,5 @@ error[E01]: cow may not jump during new moon.
   │   -- Cow range does not start at boundary.
   │   ------ Cow does not start or end at boundary.
   │     -- Cow range does not end at boundary.
-  │
 
 


### PR DESCRIPTION
This omits the trailing border on the final snippet if no notes are present.

For example, originally we’d render:
```
error[E0499]: cannot borrow `v` as mutable more than once at a time
  ┌─ one_line.rs:3:5
  │
3 │     v.push(v.pop().unwrap());
  │     - first borrow later used by call
  │       ---- first mutable borrow occurs here
  │            ^ second mutable borrow occurs here
  │

error: aborting due to previous error
 = For more information about this error, try `rustc --explain E0499`.

```
…where as now we’ll render:
```
error[E0499]: cannot borrow `v` as mutable more than once at a time
  ┌─ one_line.rs:3:5
  │
3 │     v.push(v.pop().unwrap());
  │     - first borrow later used by call
  │       ---- first mutable borrow occurs here
  │            ^ second mutable borrow occurs here

error: aborting due to previous error
 = For more information about this error, try `rustc --explain E0499`.

```