### PR TITLE
 Allow using codespan without codespan-reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
         with:
           command: check
           args: --manifest-path "codespan/Cargo.toml" --features "serialization"
+      - name: Run cargo test for codespan without codespan-reporting
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path "codespan/Cargo.toml" --no-default-features
       - name: Run cargo test for codespan-lsp
         uses: actions-rs/cargo@v1
         with:

--- a/codespan-reporting/src/files.rs
+++ b/codespan-reporting/src/files.rs
@@ -191,6 +191,7 @@ pub fn column_index(source: &str, line_range: Range<usize>, byte_index: usize) -
 ///
 /// assert_eq!(line_index(&line_starts, 5), Some(1));
 /// ```
+// NOTE: this is copied in `codespan::file::line_starts` and should be kept in sync.
 pub fn line_starts<'source>(source: &'source str) -> impl 'source + Iterator<Item = usize> {
     std::iter::once(0).chain(source.match_indices('\n').map(|(i, _)| i + 1))
 }

--- a/codespan/src/file.rs
+++ b/codespan/src/file.rs
@@ -341,7 +341,7 @@ where
     Source: AsRef<str>,
 {
     fn new(name: OsString, source: Source) -> Self {
-        let line_starts = codespan_reporting::files::line_starts(source.as_ref())
+        let line_starts = line_starts(source.as_ref())
             .map(|i| ByteIndex::from(i as u32))
             .collect();
 
@@ -353,7 +353,7 @@ where
     }
 
     fn update(&mut self, source: Source) {
-        let line_starts = codespan_reporting::files::line_starts(source.as_ref())
+        let line_starts = line_starts(source.as_ref())
             .map(|i| ByteIndex::from(i as u32))
             .collect();
         self.source = source;
@@ -441,6 +441,11 @@ where
             SpanOutOfBoundsError { given: span, span }
         })
     }
+}
+
+// NOTE: this is copied from `codespan_reporting::files::line_starts` and should be kept in sync.
+fn line_starts<'source>(source: &'source str) -> impl 'source + Iterator<Item = usize> {
+    std::iter::once(0).chain(source.match_indices('\n').map(|(i, _)| i + 1))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This copies the implementation of `line_starts` to `codespan`. It also adds `--no-default-features` to CI.

r? @brendanzab 