### PR TITLE
Remove Files trait, switch to a more dynamic file fetching system

### DIFF
--- a/codespan-reporting/examples/peg_calculator.rs
+++ b/codespan-reporting/examples/peg_calculator.rs
@@ -61,7 +61,7 @@ fn main() -> anyhow::Result<()> {
                     ])
                     .with_notes(vec![format!("expected: {}", error.expected)]);
 
-                term::emit(&mut writer.lock(), &config, &file, &diagnostic)?;
+                term::emit(&mut writer.lock(), &config, |_| &file, &diagnostic)?;
             }
         }
     }

--- a/codespan-reporting/examples/readme_preview.rs
+++ b/codespan-reporting/examples/readme_preview.rs
@@ -87,7 +87,7 @@ fn main() -> anyhow::Result<()> {
             };
 
             for diagnostic in &diagnostics {
-                term::emit(&mut writer, &config, &file, &diagnostic)?;
+                term::emit(&mut writer, &config, |_| &file, &diagnostic)?;
             }
 
             let num_lines = buffer.iter().filter(|byte| **byte == b'\n').count() + 1;
@@ -178,7 +178,7 @@ fn main() -> anyhow::Result<()> {
             let writer = StandardStream::stderr(color.into());
             let config = codespan_reporting::term::Config::default();
             for diagnostic in &diagnostics {
-                term::emit(&mut writer.lock(), &config, &file, &diagnostic)?;
+                term::emit(&mut writer.lock(), &config, |_| &file, &diagnostic)?;
             }
         }
     }

--- a/codespan-reporting/examples/reusable_diagnostic.rs
+++ b/codespan-reporting/examples/reusable_diagnostic.rs
@@ -42,7 +42,7 @@ fn main() -> anyhow::Result<()> {
     let writer = StandardStream::stderr(opts.color.into());
     let config = codespan_reporting::term::Config::default();
     for diagnostic in errors.iter().map(Error::report) {
-        term::emit(&mut writer.lock(), &config, &file, &diagnostic)?;
+        term::emit(&mut writer.lock(), &config, |_| &file, &diagnostic)?;
     }
 
     Ok(())

--- a/codespan-reporting/examples/term.rs
+++ b/codespan-reporting/examples/term.rs
@@ -168,7 +168,7 @@ fn main() -> anyhow::Result<()> {
     let writer = StandardStream::stderr(opts.color.into());
     let config = codespan_reporting::term::Config::default();
     for diagnostic in &diagnostics {
-        term::emit(&mut writer.lock(), &config, &files, &diagnostic)?;
+        term::emit(&mut writer.lock(), &config, |id| files.get(id).unwrap(), &diagnostic)?;
     }
 
     Ok(())

--- a/codespan-reporting/tests/support/mod.rs
+++ b/codespan-reporting/tests/support/mod.rs
@@ -1,5 +1,5 @@
 use codespan_reporting::diagnostic::Diagnostic;
-use codespan_reporting::files::Files;
+use codespan_reporting::files::{Files, RefSrc};
 use codespan_reporting::term::{emit, Config};
 use termcolor::{Buffer, WriteColor};
 
@@ -15,7 +15,7 @@ pub struct TestData<'files, F: Files<'files>> {
 impl<'files, F: Files<'files>> TestData<'files, F> {
     fn emit<W: WriteColor>(&'files self, mut writer: W, config: &Config) -> W {
         for diagnostic in &self.diagnostics {
-            emit(&mut writer, config, &self.files, &diagnostic).unwrap();
+            emit(&mut writer, config, |id| self.files.get(id).unwrap(), &diagnostic).unwrap();
         }
         writer
     }


### PR DESCRIPTION
This PR is only partially complete. In theory is removes a lot of the complexity surrounding the `Files` trait while also making the API more useful for users. Right now, `Files` has not been removed and as such, a lot of extra code is used to allow compatibility between both the old and new system. This will be removed in time and complexity shall be significantly reduced.