### PR TITLE
errors instead of panics

### DIFF
--- a/codespan-reporting/src/files.rs
+++ b/codespan-reporting/src/files.rs
@@ -95,7 +95,7 @@ pub trait Files<'a> {
         Some(column_index + 1)
     }
 
-    /// Convenience method for returning line and column number at the given a
+    /// Convenience method for returning line and column number at the given
     /// byte index in the file.
     fn location(&'a self, id: Self::FileId, byte_index: usize) -> Option<Location> {
         let line_index = self.line_index(id, byte_index)?;

--- a/codespan-reporting/src/term.rs
+++ b/codespan-reporting/src/term.rs
@@ -28,6 +28,21 @@ impl From<std::io::Error> for RenderError {
     }
 }
 
+impl std::fmt::Display for RenderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f,"{:?}",self)
+    }
+}
+
+impl std::error::Error for RenderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self{
+            RenderError::IO(e)=>Some(e),
+            _=>None,
+        }
+    }
+}
+
 /// A command line argument that configures the coloring of the output.
 ///
 /// This can be used with command line argument parsers like [`clap`] or [`structopt`].
@@ -100,7 +115,7 @@ pub fn emit<'files, F: Files<'files>>(
     config: &Config,
     files: &'files F,
     diagnostic: &Diagnostic<F::FileId>,
-) -> io::Result<()> {
+) -> Result<(), RenderError> {
     use self::renderer::Renderer;
     use self::views::{RichDiagnostic, ShortDiagnostic};
 

--- a/codespan-reporting/src/term.rs
+++ b/codespan-reporting/src/term.rs
@@ -16,6 +16,7 @@ pub use self::config::{Chars, Config, DisplayStyle, Styles};
 
 /// An enum representing an error that happened while rendering a diagnostic.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum RenderError {
     FileMissing,
     InvalidIndex,

--- a/codespan-reporting/src/term.rs
+++ b/codespan-reporting/src/term.rs
@@ -31,7 +31,11 @@ impl From<std::io::Error> for RenderError {
 
 impl std::fmt::Display for RenderError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            RenderError::FileMissing => write!(f, "file missing"),
+            RenderError::InvalidIndex => write!(f, "invalid index"),
+            RenderError::IO(err) => write!(f, "{:?}", err),
+        }
     }
 }
 

--- a/codespan-reporting/src/term.rs
+++ b/codespan-reporting/src/term.rs
@@ -34,7 +34,7 @@ impl std::fmt::Display for RenderError {
         match self {
             RenderError::FileMissing => write!(f, "file missing"),
             RenderError::InvalidIndex => write!(f, "invalid index"),
-            RenderError::Io(err) => write!(f, "{:?}", err),
+            RenderError::Io(err) => write!(f, "{}", err),
         }
     }
 }

--- a/codespan-reporting/src/term.rs
+++ b/codespan-reporting/src/term.rs
@@ -30,15 +30,15 @@ impl From<std::io::Error> for RenderError {
 
 impl std::fmt::Display for RenderError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f,"{:?}",self)
+        write!(f, "{:?}", self)
     }
 }
 
 impl std::error::Error for RenderError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match &self{
-            RenderError::IO(e)=>Some(e),
-            _=>None,
+        match &self {
+            RenderError::IO(e) => Some(e),
+            _ => None,
         }
     }
 }

--- a/codespan-reporting/src/term.rs
+++ b/codespan-reporting/src/term.rs
@@ -20,12 +20,12 @@ pub use self::config::{Chars, Config, DisplayStyle, Styles};
 pub enum RenderError {
     FileMissing,
     InvalidIndex,
-    IO(std::io::Error),
+    Io(std::io::Error),
 }
 
 impl From<std::io::Error> for RenderError {
     fn from(err: std::io::Error) -> RenderError {
-        RenderError::IO(err)
+        RenderError::Io(err)
     }
 }
 
@@ -34,7 +34,7 @@ impl std::fmt::Display for RenderError {
         match self {
             RenderError::FileMissing => write!(f, "file missing"),
             RenderError::InvalidIndex => write!(f, "invalid index"),
-            RenderError::IO(err) => write!(f, "{:?}", err),
+            RenderError::Io(err) => write!(f, "{:?}", err),
         }
     }
 }
@@ -42,7 +42,7 @@ impl std::fmt::Display for RenderError {
 impl std::error::Error for RenderError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match &self {
-            RenderError::IO(e) => Some(e),
+            RenderError::Io(err) => Some(err),
             _ => None,
         }
     }

--- a/codespan-reporting/src/term.rs
+++ b/codespan-reporting/src/term.rs
@@ -1,6 +1,5 @@
 //! Terminal back-end for emitting diagnostics.
 
-use std::io;
 use std::str::FromStr;
 use termcolor::{ColorChoice, WriteColor};
 
@@ -14,6 +13,20 @@ mod views;
 pub use termcolor;
 
 pub use self::config::{Chars, Config, DisplayStyle, Styles};
+
+/// An enum representing an error that happened while rendering a diagnostic.
+#[derive(Debug)]
+pub enum RenderError {
+    FileMissing,
+    InvalidIndex,
+    IO(std::io::Error),
+}
+
+impl From<std::io::Error> for RenderError {
+    fn from(err: std::io::Error) -> RenderError {
+        RenderError::IO(err)
+    }
+}
 
 /// A command line argument that configures the coloring of the output.
 ///

--- a/codespan-reporting/src/term/renderer.rs
+++ b/codespan-reporting/src/term/renderer.rs
@@ -4,7 +4,7 @@ use termcolor::{ColorSpec, WriteColor};
 
 use crate::diagnostic::{LabelStyle, Severity};
 use crate::files::Location;
-use crate::term::{Chars, Config, Styles};
+use crate::term::{Chars, Config, RenderError, Styles};
 
 /// The 'location focus' of a source code snippet.
 pub struct Locus {
@@ -148,7 +148,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         severity: Severity,
         code: Option<&str>,
         message: &str,
-    ) -> io::Result<()> {
+    ) -> Result<(), RenderError> {
         // Write locus
         //
         // ```text
@@ -197,9 +197,8 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     }
 
     /// Empty line.
-    pub fn render_empty(&mut self) -> io::Result<()> {
+    pub fn render_empty(&mut self) -> Result<(), RenderError> {
         write!(self, "\n")?;
-
         Ok(())
     }
 
@@ -208,7 +207,11 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     /// ```text
     /// ┌─ test:2:9
     /// ```
-    pub fn render_snippet_start(&mut self, outer_padding: usize, locus: &Locus) -> io::Result<()> {
+    pub fn render_snippet_start(
+        &mut self,
+        outer_padding: usize,
+        locus: &Locus,
+    ) -> Result<(), RenderError> {
         self.outer_gutter(outer_padding)?;
 
         self.set_color(&self.styles().source_border)?;
@@ -239,7 +242,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         single_labels: &[SingleLabel<'_>],
         num_multi_labels: usize,
         multi_labels: &[(usize, LabelStyle, MultiLabel<'_>)],
-    ) -> io::Result<()> {
+    ) -> Result<(), RenderError> {
         // Trim trailing newlines, linefeeds, and null chars from source, if they exist.
         // FIXME: Use the number of trimmed placeholders when rendering single line carets
         let source = source.trim_end_matches(['\n', '\r', '\0'].as_ref());
@@ -604,7 +607,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         severity: Severity,
         num_multi_labels: usize,
         multi_labels: &[(usize, LabelStyle, MultiLabel<'_>)],
-    ) -> io::Result<()> {
+    ) -> Result<(), RenderError> {
         self.outer_gutter(outer_padding)?;
         self.border_left()?;
         self.inner_gutter(severity, num_multi_labels, multi_labels)?;
@@ -623,7 +626,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         severity: Severity,
         num_multi_labels: usize,
         multi_labels: &[(usize, LabelStyle, MultiLabel<'_>)],
-    ) -> io::Result<()> {
+    ) -> Result<(), RenderError> {
         self.outer_gutter(outer_padding)?;
         self.border_left_break()?;
         self.inner_gutter(severity, num_multi_labels, multi_labels)?;
@@ -637,7 +640,11 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     /// = expected type `Int`
     ///      found type `String`
     /// ```
-    pub fn render_snippet_note(&mut self, outer_padding: usize, message: &str) -> io::Result<()> {
+    pub fn render_snippet_note(
+        &mut self,
+        outer_padding: usize,
+        message: &str,
+    ) -> Result<(), RenderError> {
         for (note_line_index, line) in message.lines().enumerate() {
             self.outer_gutter(outer_padding)?;
             match note_line_index {
@@ -684,25 +691,29 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     }
 
     /// Location focus.
-    fn snippet_locus(&mut self, locus: &Locus) -> io::Result<()> {
+    fn snippet_locus(&mut self, locus: &Locus) -> Result<(), RenderError> {
         write!(
             self,
             "{name}:{line_number}:{column_number}",
             name = locus.name,
             line_number = locus.location.line_number,
             column_number = locus.location.column_number,
-        )
+        )?;
+        Ok(())
     }
 
     /// The outer gutter of a source line.
-    fn outer_gutter(&mut self, outer_padding: usize) -> io::Result<()> {
-        write!(self, "{space: >width$}", space = "", width = outer_padding)?;
-        write!(self, " ")?;
+    fn outer_gutter(&mut self, outer_padding: usize) -> Result<(), RenderError> {
+        write!(self, "{space: >width$} ", space = "", width = outer_padding)?;
         Ok(())
     }
 
     /// The outer gutter of a source line, with line number.
-    fn outer_gutter_number(&mut self, line_number: usize, outer_padding: usize) -> io::Result<()> {
+    fn outer_gutter_number(
+        &mut self,
+        line_number: usize,
+        outer_padding: usize,
+    ) -> Result<(), RenderError> {
         self.set_color(&self.styles().line_number)?;
         write!(
             self,
@@ -716,7 +727,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     }
 
     /// The left-hand border of a source line.
-    fn border_left(&mut self) -> io::Result<()> {
+    fn border_left(&mut self) -> Result<(), RenderError> {
         self.set_color(&self.styles().source_border)?;
         write!(self, "{}", self.chars().source_border_left)?;
         self.reset()?;
@@ -724,7 +735,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     }
 
     /// The broken left-hand border of a source line.
-    fn border_left_break(&mut self) -> io::Result<()> {
+    fn border_left_break(&mut self) -> Result<(), RenderError> {
         self.set_color(&self.styles().source_border)?;
         write!(self, "{}", self.chars().source_border_left_break)?;
         self.reset()?;
@@ -739,7 +750,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         single_labels: &[SingleLabel<'_>],
         trailing_label: Option<(usize, &SingleLabel<'_>)>,
         char_indices: impl Iterator<Item = (usize, char)>,
-    ) -> io::Result<()> {
+    ) -> Result<(), RenderError> {
         for (metrics, ch) in self.char_metrics(char_indices) {
             let column_range = metrics.byte_index..(metrics.byte_index + ch.len_utf8());
             let label_style = hanging_labels(single_labels, trailing_label)
@@ -775,7 +786,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         severity: Severity,
         label_style: LabelStyle,
         underline: Option<LabelStyle>,
-    ) -> io::Result<()> {
+    ) -> Result<(), RenderError> {
         match underline {
             None => write!(self, " ")?,
             // Continue an underline horizontally
@@ -800,7 +811,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         &mut self,
         severity: Severity,
         label_style: LabelStyle,
-    ) -> io::Result<()> {
+    ) -> Result<(), RenderError> {
         write!(self, " ")?;
         self.set_color(self.styles().label(severity, label_style))?;
         write!(self, "{}", self.chars().multi_top_left)?;
@@ -817,7 +828,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         &mut self,
         severity: Severity,
         label_style: LabelStyle,
-    ) -> io::Result<()> {
+    ) -> Result<(), RenderError> {
         write!(self, " ")?;
         self.set_color(self.styles().label(severity, label_style))?;
         write!(self, "{}", self.chars().multi_bottom_left)?;
@@ -836,7 +847,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         label_style: LabelStyle,
         source: &str,
         range: RangeTo<usize>,
-    ) -> io::Result<()> {
+    ) -> Result<(), RenderError> {
         self.set_color(self.styles().label(severity, label_style))?;
 
         for (metrics, _) in self
@@ -870,7 +881,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         source: &str,
         range: RangeTo<usize>,
         message: &str,
-    ) -> io::Result<()> {
+    ) -> Result<(), RenderError> {
         self.set_color(self.styles().label(severity, label_style))?;
 
         for (metrics, _) in self
@@ -900,7 +911,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         &mut self,
         severity: Severity,
         underline: Option<Underline>,
-    ) -> io::Result<()> {
+    ) -> Result<(), RenderError> {
         match underline {
             None => self.inner_gutter_space(),
             Some((label_style, vertical_bound)) => {
@@ -917,8 +928,9 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     }
 
     /// Writes an empty gutter space.
-    fn inner_gutter_space(&mut self) -> io::Result<()> {
-        write!(self, "  ")
+    fn inner_gutter_space(&mut self) -> Result<(), RenderError> {
+        write!(self, "  ")?;
+        Ok(())
     }
 
     /// Writes an inner gutter, with the left lines if necessary.
@@ -927,7 +939,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         severity: Severity,
         num_multi_labels: usize,
         multi_labels: &[(usize, LabelStyle, MultiLabel<'_>)],
-    ) -> io::Result<()> {
+    ) -> Result<(), RenderError> {
         let mut multi_labels_iter = multi_labels.iter().peekable();
         for label_column in 0..num_multi_labels {
             match multi_labels_iter.peek() {

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -1,9 +1,9 @@
-use std::io;
 use std::ops::Range;
 
 use crate::diagnostic::{Diagnostic, LabelStyle};
 use crate::files::{Files, Location};
 use crate::term::renderer::{Locus, MultiLabel, Renderer, SingleLabel};
+use crate::term::RenderError;
 
 /// Count the number of decimal digits in `n`.
 fn count_digits(mut n: usize) -> usize {
@@ -13,12 +13,6 @@ fn count_digits(mut n: usize) -> usize {
         n /= 10; // remove last digit
     }
     count
-}
-
-pub enum RenderError{
-    FileMissing,
-    InvalidIndex,
-    IO(io::Error),
 }
 
 /// Output a richly formatted diagnostic, with source code previews.

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -32,7 +32,7 @@ where
         &self,
         files: &'files impl Files<'files, FileId = FileId>,
         renderer: &mut Renderer<'_, '_>,
-    ) -> Result<(),RenderError>
+    ) -> Result<(), RenderError>
     where
         FileId: 'files,
     {
@@ -83,15 +83,29 @@ where
 
         // Group labels by file
         for label in &self.diagnostic.labels {
-            let source = files.source(label.file_id).ok_or(RenderError::FileMissing)?;
+            let source = files
+                .source(label.file_id)
+                .ok_or(RenderError::FileMissing)?;
             let source = source.as_ref();
 
-            let start_line_index = files.line_index(label.file_id, label.range.start).ok_or(RenderError::InvalidIndex)?;
-            let start_line_number = files.line_number(label.file_id, start_line_index).ok_or(RenderError::InvalidIndex)?;
-            let start_line_range = files.line_range(label.file_id, start_line_index).ok_or(RenderError::InvalidIndex)?;
-            let end_line_index = files.line_index(label.file_id, label.range.end).ok_or(RenderError::InvalidIndex)?;
-            let end_line_number = files.line_number(label.file_id, end_line_index).ok_or(RenderError::InvalidIndex)?;
-            let end_line_range = files.line_range(label.file_id, end_line_index).ok_or(RenderError::InvalidIndex)?;
+            let start_line_index = files
+                .line_index(label.file_id, label.range.start)
+                .ok_or(RenderError::InvalidIndex)?;
+            let start_line_number = files
+                .line_number(label.file_id, start_line_index)
+                .ok_or(RenderError::InvalidIndex)?;
+            let start_line_range = files
+                .line_range(label.file_id, start_line_index)
+                .ok_or(RenderError::InvalidIndex)?;
+            let end_line_index = files
+                .line_index(label.file_id, label.range.end)
+                .ok_or(RenderError::InvalidIndex)?;
+            let end_line_number = files
+                .line_number(label.file_id, end_line_index)
+                .ok_or(RenderError::InvalidIndex)?;
+            let end_line_range = files
+                .line_range(label.file_id, end_line_index)
+                .ok_or(RenderError::InvalidIndex)?;
 
             outer_padding = std::cmp::max(outer_padding, count_digits(start_line_number));
             outer_padding = std::cmp::max(outer_padding, count_digits(end_line_number));
@@ -110,8 +124,9 @@ where
                     {
                         // this label indicates an earlier start and has at least the same level of style
                         labeled_file.start = label.range.start;
-                        labeled_file.location =
-                            files.location(label.file_id, label.range.start).ok_or(RenderError::InvalidIndex)?;
+                        labeled_file.location = files
+                            .location(label.file_id, label.range.start)
+                            .ok_or(RenderError::InvalidIndex)?;
                         labeled_file.max_label_style = label.style;
                     }
                     labeled_file
@@ -121,14 +136,21 @@ where
                     labeled_files.push(LabeledFile {
                         file_id: label.file_id,
                         start: label.range.start,
-                        name: files.name(label.file_id).ok_or(RenderError::FileMissing)?.to_string(),
-                        location: files.location(label.file_id, label.range.start).ok_or(RenderError::InvalidIndex)?,
+                        name: files
+                            .name(label.file_id)
+                            .ok_or(RenderError::FileMissing)?
+                            .to_string(),
+                        location: files
+                            .location(label.file_id, label.range.start)
+                            .ok_or(RenderError::InvalidIndex)?,
                         num_multi_labels: 0,
                         lines: BTreeMap::new(),
                         max_label_style: label.style,
                     });
                     // this unwrap should never fail because we just pushed an element
-                    labeled_files.last_mut().expect("just pushed an element that disappeared")
+                    labeled_files
+                        .last_mut()
+                        .expect("just pushed an element that disappeared")
                 }
             };
 
@@ -231,8 +253,12 @@ where
                 // 7 │ │     _ 0 => "Buzz"
                 // ```
                 for line_index in (start_line_index + 1)..end_line_index {
-                    let line_range = files.line_range(label.file_id, line_index).ok_or(RenderError::InvalidIndex)?;
-                    let line_number = files.line_number(label.file_id, line_index).ok_or(RenderError::InvalidIndex)?;
+                    let line_range = files
+                        .line_range(label.file_id, line_index)
+                        .ok_or(RenderError::InvalidIndex)?;
+                    let line_number = files
+                        .line_number(label.file_id, line_index)
+                        .ok_or(RenderError::InvalidIndex)?;
 
                     outer_padding = std::cmp::max(outer_padding, count_digits(line_number));
 
@@ -298,7 +324,9 @@ where
         // ```
         let mut labeled_files = labeled_files.into_iter().peekable();
         while let Some(labeled_file) = labeled_files.next() {
-            let source = files.source(labeled_file.file_id).ok_or(RenderError::FileMissing)?;
+            let source = files
+                .source(labeled_file.file_id)
+                .ok_or(RenderError::FileMissing)?;
             let source = source.as_ref();
 
             // Top left border and locus.
@@ -359,8 +387,12 @@ where
 
                             renderer.render_snippet_source(
                                 outer_padding,
-                                files.line_number(file_id, line_index + 1).ok_or(RenderError::InvalidIndex)?,
-                                &source[files.line_range(file_id, line_index + 1).ok_or(RenderError::InvalidIndex)?],
+                                files
+                                    .line_number(file_id, line_index + 1)
+                                    .ok_or(RenderError::InvalidIndex)?,
+                                &source[files
+                                    .line_range(file_id, line_index + 1)
+                                    .ok_or(RenderError::InvalidIndex)?],
                                 self.diagnostic.severity,
                                 &[],
                                 labeled_file.num_multi_labels,
@@ -411,9 +443,7 @@ where
         for note in &self.diagnostic.notes {
             renderer.render_snippet_note(outer_padding, note)?;
         }
-        renderer.render_empty()?;
-
-        Ok(())
+        renderer.render_empty()
     }
 }
 
@@ -436,7 +466,7 @@ where
         &self,
         files: &'files impl Files<'files, FileId = FileId>,
         renderer: &mut Renderer<'_, '_>,
-    ) -> Result<(),RenderError>
+    ) -> Result<(), RenderError>
     where
         FileId: 'files,
     {
@@ -452,8 +482,13 @@ where
 
             renderer.render_header(
                 Some(&Locus {
-                    name: files.name(label.file_id).ok_or(RenderError::FileMissing)?.to_string(),
-                    location: files.location(label.file_id, label.range.start).ok_or(RenderError::InvalidIndex)?,
+                    name: files
+                        .name(label.file_id)
+                        .ok_or(RenderError::FileMissing)?
+                        .to_string(),
+                    location: files
+                        .location(label.file_id, label.range.start)
+                        .ok_or(RenderError::InvalidIndex)?,
                 }),
                 self.diagnostic.severity,
                 self.diagnostic.code.as_ref().map(String::as_str),
@@ -472,7 +507,7 @@ where
                 self.diagnostic.severity,
                 self.diagnostic.code.as_ref().map(String::as_str),
                 self.diagnostic.message.as_str(),
-            ).map_err(|e| RenderError::IO(e))?;
+            )?;
         }
 
         Ok(())

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -15,6 +15,12 @@ fn count_digits(mut n: usize) -> usize {
     count
 }
 
+pub enum RenderError{
+    FileMissing,
+    InvalidIndex,
+    IO(io::Error),
+}
+
 /// Output a richly formatted diagnostic, with source code previews.
 pub struct RichDiagnostic<'diagnostic, FileId> {
     diagnostic: &'diagnostic Diagnostic<FileId>,
@@ -32,7 +38,7 @@ where
         &self,
         files: &'files impl Files<'files, FileId = FileId>,
         renderer: &mut Renderer<'_, '_>,
-    ) -> io::Result<()>
+    ) -> Result<(),RenderError>
     where
         FileId: 'files,
     {
@@ -83,15 +89,15 @@ where
 
         // Group labels by file
         for label in &self.diagnostic.labels {
-            let source = files.source(label.file_id).unwrap();
+            let source = files.source(label.file_id).ok_or(RenderError::FileMissing)?;
             let source = source.as_ref();
 
-            let start_line_index = files.line_index(label.file_id, label.range.start).unwrap();
-            let start_line_number = files.line_number(label.file_id, start_line_index).unwrap();
-            let start_line_range = files.line_range(label.file_id, start_line_index).unwrap();
-            let end_line_index = files.line_index(label.file_id, label.range.end).unwrap();
-            let end_line_number = files.line_number(label.file_id, end_line_index).unwrap();
-            let end_line_range = files.line_range(label.file_id, end_line_index).unwrap();
+            let start_line_index = files.line_index(label.file_id, label.range.start).ok_or(RenderError::InvalidIndex)?;
+            let start_line_number = files.line_number(label.file_id, start_line_index).ok_or(RenderError::InvalidIndex)?;
+            let start_line_range = files.line_range(label.file_id, start_line_index).ok_or(RenderError::InvalidIndex)?;
+            let end_line_index = files.line_index(label.file_id, label.range.end).ok_or(RenderError::InvalidIndex)?;
+            let end_line_number = files.line_number(label.file_id, end_line_index).ok_or(RenderError::InvalidIndex)?;
+            let end_line_range = files.line_range(label.file_id, end_line_index).ok_or(RenderError::InvalidIndex)?;
 
             outer_padding = std::cmp::max(outer_padding, count_digits(start_line_number));
             outer_padding = std::cmp::max(outer_padding, count_digits(end_line_number));
@@ -111,7 +117,7 @@ where
                         // this label indicates an earlier start and has at least the same level of style
                         labeled_file.start = label.range.start;
                         labeled_file.location =
-                            files.location(label.file_id, label.range.start).unwrap();
+                            files.location(label.file_id, label.range.start).ok_or(RenderError::InvalidIndex)?;
                         labeled_file.max_label_style = label.style;
                     }
                     labeled_file
@@ -121,13 +127,14 @@ where
                     labeled_files.push(LabeledFile {
                         file_id: label.file_id,
                         start: label.range.start,
-                        name: files.name(label.file_id).unwrap().to_string(),
-                        location: files.location(label.file_id, label.range.start).unwrap(),
+                        name: files.name(label.file_id).ok_or(RenderError::FileMissing)?.to_string(),
+                        location: files.location(label.file_id, label.range.start).ok_or(RenderError::InvalidIndex)?,
                         num_multi_labels: 0,
                         lines: BTreeMap::new(),
                         max_label_style: label.style,
                     });
-                    labeled_files.last_mut().unwrap()
+                    // this unwrap should never fail because we just pushed an element
+                    labeled_files.last_mut().expect("just pushed an element that disappeared")
                 }
             };
 
@@ -230,8 +237,8 @@ where
                 // 7 │ │     _ 0 => "Buzz"
                 // ```
                 for line_index in (start_line_index + 1)..end_line_index {
-                    let line_range = files.line_range(label.file_id, line_index).unwrap();
-                    let line_number = files.line_number(label.file_id, line_index).unwrap();
+                    let line_range = files.line_range(label.file_id, line_index).ok_or(RenderError::InvalidIndex)?;
+                    let line_number = files.line_number(label.file_id, line_index).ok_or(RenderError::InvalidIndex)?;
 
                     outer_padding = std::cmp::max(outer_padding, count_digits(line_number));
 
@@ -297,7 +304,7 @@ where
         // ```
         let mut labeled_files = labeled_files.into_iter().peekable();
         while let Some(labeled_file) = labeled_files.next() {
-            let source = files.source(labeled_file.file_id).unwrap();
+            let source = files.source(labeled_file.file_id).ok_or(RenderError::FileMissing)?;
             let source = source.as_ref();
 
             // Top left border and locus.
@@ -358,8 +365,8 @@ where
 
                             renderer.render_snippet_source(
                                 outer_padding,
-                                files.line_number(file_id, line_index + 1).unwrap(),
-                                &source[files.line_range(file_id, line_index + 1).unwrap()],
+                                files.line_number(file_id, line_index + 1).ok_or(RenderError::InvalidIndex)?,
+                                &source[files.line_range(file_id, line_index + 1).ok_or(RenderError::InvalidIndex)?],
                                 self.diagnostic.severity,
                                 &[],
                                 labeled_file.num_multi_labels,
@@ -435,7 +442,7 @@ where
         &self,
         files: &'files impl Files<'files, FileId = FileId>,
         renderer: &mut Renderer<'_, '_>,
-    ) -> io::Result<()>
+    ) -> Result<(),RenderError>
     where
         FileId: 'files,
     {
@@ -451,8 +458,8 @@ where
 
             renderer.render_header(
                 Some(&Locus {
-                    name: files.name(label.file_id).unwrap().to_string(),
-                    location: files.location(label.file_id, label.range.start).unwrap(),
+                    name: files.name(label.file_id).ok_or(RenderError::FileMissing)?.to_string(),
+                    location: files.location(label.file_id, label.range.start).ok_or(RenderError::InvalidIndex)?,
                 }),
                 self.diagnostic.severity,
                 self.diagnostic.code.as_ref().map(String::as_str),
@@ -471,7 +478,7 @@ where
                 self.diagnostic.severity,
                 self.diagnostic.code.as_ref().map(String::as_str),
                 self.diagnostic.message.as_str(),
-            )?;
+            ).map_err(|e| RenderError::IO(e))?;
         }
 
         Ok(())

--- a/codespan/src/file.rs
+++ b/codespan/src/file.rs
@@ -78,6 +78,7 @@ impl FileId {
     const OFFSET: u32 = 1;
 
     fn new(index: usize) -> FileId {
+        // this unwrap should never fail
         FileId(NonZeroU32::new(index as u32 + Self::OFFSET).unwrap())
     }
 

--- a/codespan/src/file.rs
+++ b/codespan/src/file.rs
@@ -78,8 +78,7 @@ impl FileId {
     const OFFSET: u32 = 1;
 
     fn new(index: usize) -> FileId {
-        // this unwrap should never fail
-        FileId(NonZeroU32::new(index as u32 + Self::OFFSET).unwrap())
+        FileId(NonZeroU32::new(index as u32 + Self::OFFSET).expect("file index cannot be stored"))
     }
 
     fn get(self) -> usize {


### PR DESCRIPTION
resolves #189 

This is just a first idea of how it could look like. One point right away to consider is when some of these unwraps might fail and if the errors should be more specific then.

Something else is also that `std::io::Error` has to be wrapped. Maybe there is a nicer solution for that.