### PR TITLE
remove indirection for configuration access

### DIFF
--- a/codespan-reporting/src/term.rs
+++ b/codespan-reporting/src/term.rs
@@ -126,7 +126,7 @@ pub fn emit<'files, F: Files<'files>>(
 
     let mut renderer = Renderer::new(writer, config);
     match config.display_style {
-        DisplayStyle::Rich => RichDiagnostic::new(diagnostic).render(files, &mut renderer),
+        DisplayStyle::Rich => RichDiagnostic::new(diagnostic, config).render(files, &mut renderer),
         DisplayStyle::Short => ShortDiagnostic::new(diagnostic).render(files, &mut renderer),
     }
 }

--- a/codespan-reporting/src/term/renderer.rs
+++ b/codespan-reporting/src/term/renderer.rs
@@ -127,16 +127,6 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         &self.config.styles
     }
 
-    // FIXME: Architectural smell - we'd prefer not to pass information from the renderer to the view.
-    pub fn start_context_lines(&self) -> usize {
-        self.config.start_context_lines
-    }
-
-    // FIXME: Architectural smell - we'd prefer not to pass information from the renderer to the view.
-    pub fn end_context_lines(&self) -> usize {
-        self.config.end_context_lines
-    }
-
     /// Diagnostic header, with severity, code, and message.
     ///
     /// ```text

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use crate::diagnostic::{Diagnostic, LabelStyle};
 use crate::files::{Files, Location};
 use crate::term::renderer::{Locus, MultiLabel, Renderer, SingleLabel};
-use crate::term::RenderError;
+use crate::term::{Config, RenderError};
 
 /// Count the number of decimal digits in `n`.
 fn count_digits(mut n: usize) -> usize {
@@ -16,16 +16,20 @@ fn count_digits(mut n: usize) -> usize {
 }
 
 /// Output a richly formatted diagnostic, with source code previews.
-pub struct RichDiagnostic<'diagnostic, FileId> {
+pub struct RichDiagnostic<'diagnostic, 'config, FileId> {
     diagnostic: &'diagnostic Diagnostic<FileId>,
+    config: &'config Config,
 }
 
-impl<'diagnostic, FileId> RichDiagnostic<'diagnostic, FileId>
+impl<'diagnostic, 'config, FileId> RichDiagnostic<'diagnostic, 'config, FileId>
 where
     FileId: Copy + PartialEq,
 {
-    pub fn new(diagnostic: &'diagnostic Diagnostic<FileId>) -> RichDiagnostic<'diagnostic, FileId> {
-        RichDiagnostic { diagnostic }
+    pub fn new(
+        diagnostic: &'diagnostic Diagnostic<FileId>,
+        config: &'config Config,
+    ) -> RichDiagnostic<'diagnostic, 'config, FileId> {
+        RichDiagnostic { diagnostic, config }
     }
 
     pub fn render<'files>(
@@ -270,10 +274,10 @@ where
                     // The line should be rendered to match the configuration of how much context to show.
                     line.must_render |=
                         // Is this line part of the context after the start of the label?
-                        line_index - start_line_index <= renderer.start_context_lines()
+                        line_index - start_line_index <= self.config.start_context_lines
                         ||
                         // Is this line part of the context before the end of the label?
-                        end_line_index - line_index <= renderer.end_context_lines();
+                        end_line_index - line_index <= self.config.end_context_lines;
                 }
 
                 // Last labeled line


### PR DESCRIPTION
This removes the architectural smell of accessing the configuration for the view through the renderer.

The chosen solution is to hand another reference of the `Config` struct to the view.

I only added this onto `RichDiagnostic` because only it accesses the configuration and the compiler complains if a struct has an unused field.