### PR TITLE
Fix build on wasm with `serialization` feature

### DIFF
--- a/codespan/src/file.rs
+++ b/codespan/src/file.rs
@@ -326,7 +326,11 @@ where
 
 /// A file that is stored in the database.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
+// `Serialize` is only implemented on `OsString` for windows/unix
+#[cfg_attr(
+    all(feature = "serialization", any(windows, unix)),
+    derive(Deserialize, Serialize)
+)]
 struct File<Source> {
     /// The name of the file.
     name: OsString,


### PR DESCRIPTION
`serde` only implements `Serialize` for `OsString` on unix and windows, so this didn't compile previously.

This PR just does the most minimal change of disabling the `Serialize` impl on wasm.