### PR TITLE
Do not render diagnostic code if it is an empty string

### DIFF
--- a/codespan-reporting/src/term/renderer.rs
+++ b/codespan-reporting/src/term/renderer.rs
@@ -168,7 +168,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         // ```text
         // [E0001]
         // ```
-        if let Some(code) = &code {
+        if let Some(code) = &code.filter(|code| code.is_empty()) {
             write!(self, "[{}]", code)?;
         }
 

--- a/codespan-reporting/src/term/renderer.rs
+++ b/codespan-reporting/src/term/renderer.rs
@@ -168,7 +168,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
         // ```text
         // [E0001]
         // ```
-        if let Some(code) = &code.filter(|code| code.is_empty()) {
+        if let Some(code) = &code.filter(|code| !code.is_empty()) {
             write!(self, "[{}]", code)?;
         }
 

--- a/codespan-reporting/tests/snapshots/term__message_errorcode__rich_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__message_errorcode__rich_no_color.snap
@@ -1,0 +1,21 @@
+---
+source: codespan-reporting/tests/term.rs
+expression: TEST_DATA.emit_no_color(&config)
+---
+error[E0001]: a message
+
+warning[W001]: a message
+
+note[N0815]: a message
+
+help[H4711]: a message
+
+error: where did my errorcode go?
+
+warning: where did my errorcode go?
+
+note: where did my errorcode go?
+
+help: where did my errorcode go?
+
+

--- a/codespan-reporting/tests/snapshots/term__message_errorcode__short_no_color.snap
+++ b/codespan-reporting/tests/snapshots/term__message_errorcode__short_no_color.snap
@@ -1,0 +1,13 @@
+---
+source: codespan-reporting/tests/term.rs
+expression: TEST_DATA.emit_no_color(&config)
+---
+error[E0001]: a message
+warning[W001]: a message
+note[N0815]: a message
+help[H4711]: a message
+error: where did my errorcode go?
+warning: where did my errorcode go?
+note: where did my errorcode go?
+help: where did my errorcode go?
+

--- a/codespan-reporting/tests/term.rs
+++ b/codespan-reporting/tests/term.rs
@@ -325,6 +325,32 @@ mod message_and_notes {
     test_emit!(short_no_color);
 }
 
+mod message_errorcode {
+    use super::*;
+
+    lazy_static::lazy_static! {
+        static ref TEST_DATA: TestData<'static, SimpleFiles<&'static str, &'static str>> = {
+            let files = SimpleFiles::new();
+
+            let diagnostics = vec![
+                Diagnostic::error().with_message("a message").with_code("E0001"),
+                Diagnostic::warning().with_message("a message").with_code("W001"),
+                Diagnostic::note().with_message("a message").with_code("N0815"),
+                Diagnostic::help().with_message("a message").with_code("H4711"),
+                Diagnostic::error().with_message("where did my errorcode go?").with_code(""),
+                Diagnostic::warning().with_message("where did my errorcode go?").with_code(""),
+                Diagnostic::note().with_message("where did my errorcode go?").with_code(""),
+                Diagnostic::help().with_message("where did my errorcode go?").with_code(""),
+            ];
+
+            TestData { files, diagnostics }
+        };
+    }
+
+    test_emit!(rich_no_color);
+    test_emit!(short_no_color);
+}
+
 mod empty_ranges {
     use super::*;
 


### PR DESCRIPTION
Pretty much what the title says 😄 
If the code is some but it is empty then codespan will currently still render it, which results in an ugly `error[]`, this fixes that.