### PR TITLE
Add a contributing guide and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,55 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment,
+we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone,
+regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct,
+or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a moderator on [#codespan:matrix.org](https://app.element.io/#/room/#codespan:matrix.org) using a "Direct message".
+The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances.
+The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,3 +43,18 @@ Contributions should:
   Include the reasoning behind each change, and the testing done.
 
 [commit-messages]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+
+## Release Process
+
+1. Bump the version numbers of each crate appropriately.
+1. Update the changelogs with the new version ranges.
+1. Create a new PR for the release, and if it passes CI merge it.
+1. Create a new tag for the release, pointing to the merge commit.
+1. Run the following commands in order from the root of the repository.
+    Note that doing this too quickly may result in an error,
+    due to a server-side delay in crate publishing:
+    ```
+    cd codespan-reporting && cargo publish; cd ..
+    cd codespan && cargo publish; cd ..
+    cd codespan-lsp && cargo publish; cd ..
+    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,13 +5,13 @@
 Please note that this project is released with a [Code of Conduct](./CODE_OF_CONDUCT.md).
 By participating in this project you agree to abide by its terms.
 
-## Matrix room
+## Matrix Room
 
 Joining the matrix room at [#codespan:matrix.org][codespan-matrix] is a good way to get in touch with the developers and community.
 
 [codespan-matrix]: https://app.element.io/#/room/#codespan:matrix.org
 
-## Workflow
+## Contribution Workflow
 
 Follow these steps to contribute to the project:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,14 @@
 # Contributing
 
+## Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Matrix Room](#matrix-room)
+- [Reporting Bugs and Suggesting Improvements](#reporting-bugs-and-suggesting-improvements)
+- [Contribution Workflow](#contribution-workflow)
+- [Quality Standards](#quality-standards)
+- [Release Process](#release-process)
+
 ## Code of Conduct
 
 Please note that this project is released with a [Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,23 @@
 
 ## Contents
 
+- [Introduction](#introduction)
 - [Code of Conduct](#code-of-conduct)
 - [Matrix Room](#matrix-room)
 - [Reporting Bugs and Suggesting Improvements](#reporting-bugs-and-suggesting-improvements)
 - [Contribution Workflow](#contribution-workflow)
 - [Quality Standards](#quality-standards)
 - [Release Process](#release-process)
+
+## Introduction
+
+Hello, and welcome to the contributing guide for Codespan!
+
+Codespan is mostly maintained in the spare time of contributors,
+so immediate reactions are not to be expected!
+By following this guide you'll make it easier for us to address your issues or incorporate your contributions.
+
+We look forward to working with you!
 
 ## Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+## Code of Conduct
+
+Please note that this project is released with a [Code of Conduct](./CODE_OF_CONDUCT.md).
+By participating in this project you agree to abide by its terms.
+
+## Matrix room
+
+Joining the matrix room at [#codespan:matrix.org][codespan-matrix] is a good way to get in touch with the developers and community.
+
+[codespan-matrix]: https://app.element.io/#/room/#codespan:matrix.org
+
+## Workflow
+
+Follow these steps to contribute to the project:
+
+1. Make a fork of the [codespan repository][codespan-repo].
+1. Within your fork, create a branch for your contribution. Use a meaningful name.
+1. Create your contribution, meeting all [contribution quality standards](#quality-standards).
+1. Ensure all the tests pass (`cargo test`).
+1. [Create a pull request][create-a-pr] against the `master` branch of the repository.
+1. Once the pull request is reviewed and CI passes, it will be merged.
+
+[codespan-repo]: https://github.com/brendanzab/codespan
+[create-a-pr]: https://help.github.com/articles/creating-a-pull-request-from-a-fork/
+
+## Quality Standards
+
+Most quality and style standards are checked automatically by the CI build.
+Contributions should:
+
+- Separate each **logical change** into its own commit.
+- Include tests for any new functionality and fixed issues in your pull request.
+- Update the changelogs with any added, removed, changed, or fixed functionality.
+- Document public functions.
+- Format code with `cargo fmt`.
+- Avoid adding `unsafe` code.
+  If it is necessary, provide an explanatory comment on any `unsafe` block explaining its rationale and why it's safe.
+- Add a descriptive message for each commit.
+  Follow [these commit message guidelines][commit-messages].
+- Document your pull requests.
+  Include the reasoning behind each change, and the testing done.
+
+[commit-messages]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,26 @@ Joining the matrix room at [#codespan:matrix.org][codespan-matrix] is a good way
 
 [codespan-matrix]: https://app.element.io/#/room/#codespan:matrix.org
 
+## Reporting Bugs and Suggesting Improvements
+
+Bugs (unwanted behaviour) and suggested improvements are tracked as [GitHub issues][github-issues].
+Before reporting an issue, please check the following points:
+
+1. The issue is caused by `codespan-reporting` itself and not by how it is used.
+  Have a look at the documentation if you are not sure.
+  If the documentation is not helpful, you can contact the developers at the above matrix chat address or make an issue.
+1. Your issue has not already been reported by someone else.
+  Please look through the open issues in the [issue tracker][github-issues].
+
+When reporting an issue, please add as much relevant information as possible.
+This will help developers and maintainers to resolve your issue. Some things you might consider:
+
+* Use a descriptive title.
+* Describe how a problem can be reproduced. Ideally give a minimal example.
+* Explain what exactly is the problem and what you expect instead. If it is related to rendering, add screenshots or other illustrations.
+
+[github-issues]: https://github.com/brendanzab/codespan/issues
+
 ## Contribution Workflow
 
 Follow these steps to contribute to the project:

--- a/README.md
+++ b/README.md
@@ -136,3 +136,8 @@ These are all ultimately inspired by rustc's excellent [error reporting infrastr
 [codemap]: https://crates.io/crates/codemap
 [language-reporting]: https://crates.io/crates/language-reporting
 [librustc_errors]: https://github.com/rust-lang/rust/tree/master/src/librustc_errors
+
+## Code of Conduct
+
+Please note that this project is released with a [Code of Conduct](./CODE_OF_CONDUCT.md).
+By participating in this project you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ These are all ultimately inspired by rustc's excellent [error reporting infrastr
 [language-reporting]: https://crates.io/crates/language-reporting
 [librustc_errors]: https://github.com/rust-lang/rust/tree/master/src/librustc_errors
 
+## Contributing
+
+A guide to contributing to codespan-reporting [can be found here](/CONTRIBUTING.md).
+
 ## Code of Conduct
 
 Please note that this project is released with a [Code of Conduct](./CODE_OF_CONDUCT.md).


### PR DESCRIPTION
This begins work on a contributing guide, and adds a code of conduct.

I've documented my release process, but it's not the nicest. We might want to re-think it before we call #272 done, perhaps recommending `cargo-release`?