### PR TITLE
move handling of label start to renderer (TODO comment)

### DIFF
--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -83,11 +83,6 @@ where
 
         // Group labels by file
         for label in &self.diagnostic.labels {
-            let source = files
-                .source(label.file_id)
-                .ok_or(RenderError::FileMissing)?;
-            let source = source.as_ref();
-
             let start_line_index = files
                 .line_index(label.file_id, label.range.start)
                 .ok_or(RenderError::InvalidIndex)?;
@@ -213,7 +208,6 @@ where
 
                 // First labeled line
                 let label_start = label.range.start - start_line_range.start;
-                let prefix_source = &source[start_line_range.start..label.range.start];
 
                 let start_line = labeled_file.get_or_insert_line(
                     start_line_index,
@@ -221,26 +215,11 @@ where
                     start_line_number,
                 );
 
-                start_line
-                    .multi_labels
-                    // TODO: Do this in the `Renderer`?
-                    .push(match prefix_source.trim() {
-                        // Section is prefixed by empty space, so we don't need to take
-                        // up a new line.
-                        //
-                        // ```text
-                        // 4 │ ╭     case (mod num 5) (mod num 3) of
-                        // ```
-                        "" => (label_index, label.style, MultiLabel::TopLeft),
-                        // There's source code in the prefix, so run a label
-                        // underneath it to get to the start of the range.
-                        //
-                        // ```text
-                        // 4 │   fizz₁ num = case (mod num 5) (mod num 3) of
-                        //   │ ╭─────────────^
-                        // ```
-                        _ => (label_index, label.style, MultiLabel::Top(..label_start)),
-                    });
+                start_line.multi_labels.push((
+                    label_index,
+                    label.style,
+                    MultiLabel::Top(..label_start),
+                ));
 
                 // The first line has to be rendered so the start of the label is visible.
                 start_line.must_render = true;

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -218,7 +218,7 @@ where
                 start_line.multi_labels.push((
                     label_index,
                     label.style,
-                    MultiLabel::Top(..label_start),
+                    MultiLabel::Top(label_start),
                 ));
 
                 // The first line has to be rendered so the start of the label is visible.
@@ -272,7 +272,7 @@ where
                 end_line.multi_labels.push((
                     label_index,
                     label.style,
-                    MultiLabel::Bottom(..label_end, &label.message),
+                    MultiLabel::Bottom(label_end, &label.message),
                 ));
 
                 // The last line has to be rendered so the end of the label is visible.


### PR DESCRIPTION
This eliminates a failure condition from `RichDiagnostic::render` because the full source code does not have to be loaded here any more.
This also allows to remove the special `TopLeft` label style from the renderer.

I am not sure if this is actually an improvement or if this complicates the renderer more so see this more as how it could look.