### PR TITLE
improve documentation in the files module

### DIFF
--- a/codespan-reporting/src/files.rs
+++ b/codespan-reporting/src/files.rs
@@ -7,7 +7,7 @@
 //! Simple implementations of this trait are implemented:
 //!
 //! - [`SimpleFile`]: For single-file use-cases
-//! - [`SimpleFiles`]: For single-file use-cases
+//! - [`SimpleFiles`]: For multi-file use-cases
 //!
 //! These data structures provide a pretty minimal API, however,
 //! so end-users are encouraged to create their own implementations for their
@@ -46,6 +46,8 @@ pub trait Files<'a> {
     fn source(&'a self, id: Self::FileId) -> Option<Self::Source>;
 
     /// The index of the line at the given byte index.
+    /// If the byte index is past the end of the file, returns the maximum line index in the file.
+    /// This means that this function only fails if the file is not present.
     ///
     /// # Note for trait implementors
     ///
@@ -59,6 +61,8 @@ pub trait Files<'a> {
     fn line_index(&'a self, id: Self::FileId, byte_index: usize) -> Option<usize>;
 
     /// The user-facing line number at the given line index.
+    /// It is not necessarily checked that the specified line index
+    /// is actually in the file.
     ///
     /// # Note for trait implementors
     ///
@@ -285,6 +289,7 @@ where
 ///
 /// This is useful for simple language tests, but it might be worth creating a
 /// custom implementation when a language scales beyond a certain size.
+/// It is a glorified `Vec<SimpleFile>` that implements the `Files` trait.
 #[derive(Debug, Clone)]
 pub struct SimpleFiles<Name, Source> {
     files: Vec<SimpleFile<Name, Source>>,


### PR DESCRIPTION
Fixed a typo in the `files` module docs (SimpleFiles is for multiple files).

Added some info for functions in the `Files` trait and to `SimpleFiles`.