### PR TITLE
change error types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,6 @@ jobs:
         with:
           command: check
           args: --manifest-path "codespan/Cargo.toml" --features "serialization"
-      - name: Run cargo test for codespan without codespan-reporting
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path "codespan/Cargo.toml" --no-default-features
       - name: Run cargo test for codespan-lsp
         uses: actions-rs/cargo@v1
         with:

--- a/codespan-lsp/CHANGELOG.md
+++ b/codespan-lsp/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   The error type in `codespan-lsp` is replaced with the error type in the `codespan-reporting` crate.
+    The error type is now `codespan_reporting::file::Error`.
+
 ## [0.10.0] - 2020-07-20
 
 ### Changed

--- a/codespan-lsp/src/lib.rs
+++ b/codespan-lsp/src/lib.rs
@@ -186,7 +186,7 @@ test
                 character: 3,
             },
         );
-        assert_eq!(result, Ok(5));
+        assert_eq!(result.unwrap(), 5);
 
         let result = position_to_byte_index(
             &files,
@@ -196,7 +196,7 @@ test
                 character: 6,
             },
         );
-        assert_eq!(result, Ok(10));
+        assert_eq!(result.unwrap(), 10);
     }
 
     #[test]
@@ -207,29 +207,29 @@ test
 
         let result = byte_index_to_position(&files, file_id, 5);
         assert_eq!(
-            result,
-            Ok(LspPosition {
+            result.unwrap(),
+            LspPosition {
                 line: 0,
                 character: 3,
-            })
+            }
         );
 
         let result = byte_index_to_position(&files, file_id, 10);
         assert_eq!(
-            result,
-            Ok(LspPosition {
+            result.unwrap(),
+            LspPosition {
                 line: 0,
                 character: 6,
-            })
+            }
         );
 
         let result = byte_index_to_position(&files, file_id2, 11);
         assert_eq!(
-            result,
-            Ok(LspPosition {
+            result.unwrap(),
+            LspPosition {
                 line: 1,
                 character: 6,
-            })
+            }
         );
     }
 }

--- a/codespan-lsp/src/lib.rs
+++ b/codespan-lsp/src/lib.rs
@@ -1,125 +1,14 @@
 //! Utilities for translating from codespan types into Language Server Protocol (LSP) types
 
-use std::{error, fmt, ops::Range};
+use std::ops::Range;
 
-use codespan_reporting::files::Files;
+use codespan_reporting::files::{Error, Files};
 
 // WARNING: Be extremely careful when adding new imports here, as it could break
 // the compatible version range that we claim in our `Cargo.toml`. This could
 // potentially break down-stream builds on a `cargo update`. This is an
 // absolute no-no, breaking much of what we enjoy about Cargo!
 use lsp_types::{Position as LspPosition, Range as LspRange};
-
-#[derive(Debug, PartialEq)]
-pub enum Error {
-    ColumnOutOfBounds { given: usize, max: usize },
-    Location(LocationError),
-    LineIndexOutOfBounds(LineIndexOutOfBoundsError),
-    SpanOutOfBounds(SpanOutOfBoundsError),
-    MissingFile,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::ColumnOutOfBounds { given, max } => {
-                write!(f, "Column out of bounds - given: {}, max: {}", given, max)
-            }
-            Error::Location(e) => e.fmt(f),
-            Error::LineIndexOutOfBounds(e) => e.fmt(f),
-            Error::SpanOutOfBounds(e) => e.fmt(f),
-            Error::MissingFile => write!(f, "File does not exit"),
-        }
-    }
-}
-
-#[derive(Debug, PartialEq)]
-pub struct LineIndexOutOfBoundsError {
-    pub given: usize,
-    pub max: usize,
-}
-
-impl error::Error for LineIndexOutOfBoundsError {}
-
-impl fmt::Display for LineIndexOutOfBoundsError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Line index out of bounds - given: {}, max: {}",
-            self.given, self.max
-        )
-    }
-}
-
-#[derive(Debug, PartialEq)]
-pub enum LocationError {
-    OutOfBounds { given: usize, span: Range<usize> },
-    InvalidCharBoundary { given: usize },
-}
-
-impl error::Error for LocationError {}
-
-impl fmt::Display for LocationError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            LocationError::OutOfBounds { given, span } => write!(
-                f,
-                "Byte index out of bounds - given: {}, span: {}..{}",
-                given, span.start, span.end
-            ),
-            LocationError::InvalidCharBoundary { given } => {
-                write!(f, "Byte index within character boundary - given: {}", given)
-            }
-        }
-    }
-}
-
-#[derive(Debug, PartialEq)]
-pub struct SpanOutOfBoundsError {
-    pub given: Range<usize>,
-    pub span: Range<usize>,
-}
-
-impl error::Error for SpanOutOfBoundsError {}
-
-impl fmt::Display for SpanOutOfBoundsError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Span out of bounds - given: {}..{}, span: {}..{}",
-            self.given.start, self.given.end, self.span.start, self.span.end
-        )
-    }
-}
-
-impl From<LocationError> for Error {
-    fn from(e: LocationError) -> Error {
-        Error::Location(e)
-    }
-}
-
-impl From<LineIndexOutOfBoundsError> for Error {
-    fn from(e: LineIndexOutOfBoundsError) -> Error {
-        Error::LineIndexOutOfBounds(e)
-    }
-}
-
-impl From<SpanOutOfBoundsError> for Error {
-    fn from(e: SpanOutOfBoundsError) -> Error {
-        Error::SpanOutOfBounds(e)
-    }
-}
-
-impl error::Error for Error {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self {
-            Error::ColumnOutOfBounds { .. } | Error::MissingFile => None,
-            Error::Location(error) => Some(error),
-            Error::LineIndexOutOfBounds(error) => Some(error),
-            Error::SpanOutOfBounds(error) => Some(error),
-        }
-    }
-}
 
 fn location_to_position(
     line_str: &str,
@@ -131,11 +20,11 @@ fn location_to_position(
         let max = line_str.len();
         let given = column;
 
-        Err(Error::ColumnOutOfBounds { given, max })
+        Err(Error::ColumnTooLarge { given, max })
     } else if !line_str.is_char_boundary(column) {
         let given = byte_index;
 
-        Err(LocationError::InvalidCharBoundary { given }.into())
+        Err(Error::InvalidCharBoundary { given })
     } else {
         let line_utf16 = line_str[..column].encode_utf16();
         let character = line_utf16.count() as u64;
@@ -153,23 +42,21 @@ pub fn byte_index_to_position<'a, F>(
 where
     F: Files<'a> + ?Sized,
 {
-    let source = files.source(file_id).ok_or_else(|| Error::MissingFile)?;
+    let source = files.source(file_id)?;
     let source = source.as_ref();
 
-    let line_index =
-        files
-            .line_index(file_id, byte_index)
-            .ok_or_else(|| LineIndexOutOfBoundsError {
-                given: byte_index,
-                max: source.lines().count(),
-            })?;
+    let line_index = files.line_index(file_id, byte_index)?;
     let line_span = files.line_range(file_id, line_index).unwrap();
 
     let line_str = source
         .get(line_span.clone())
-        .ok_or_else(|| SpanOutOfBoundsError {
-            given: line_span.clone(),
-            span: 0..source.len(),
+        .ok_or_else(|| Error::IndexTooLarge {
+            given: if line_span.start >= source.len() {
+                line_span.start
+            } else {
+                line_span.end
+            },
+            max: source.len() - 1,
         })?;
     let column = byte_index - line_span.start;
 
@@ -210,7 +97,7 @@ pub fn character_to_line_offset(line: &str, character: u64) -> Result<usize, Err
     if character_offset == character {
         Ok(line_len)
     } else {
-        Err(Error::ColumnOutOfBounds {
+        Err(Error::ColumnTooLarge {
             given: character_offset as usize,
             max: line.len(),
         })
@@ -225,7 +112,7 @@ pub fn position_to_byte_index<'a, F>(
 where
     F: Files<'a> + ?Sized,
 {
-    let source = files.source(file_id).ok_or_else(|| Error::MissingFile)?;
+    let source = files.source(file_id)?;
     let source = source.as_ref();
 
     let line_span = files.line_range(file_id, position.line as usize).unwrap();

--- a/codespan-reporting/CHANGELOG.md
+++ b/codespan-reporting/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   All errors now use the error type `codespan_reporting::file::Error`.
+    This type also replaces the custom error type for `codespan-lsp`.
+
 ## [0.9.5] - 2020-06-24
 
 ### Changed

--- a/codespan-reporting/CHANGELOG.md
+++ b/codespan-reporting/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+There is now a [code of conduct](https://github.com/brendanzab/codespan/blob/master/CODE_OF_CONDUCT.md)
+and a [contributing guide](https://github.com/brendanzab/codespan/blob/master/CONTRIBUTING.md).
+
 ### Added
 
 -   If a label spans over multiple lines, not all lines are rendered.
@@ -19,8 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   All errors now use the error type `codespan_reporting::file::Error`.
     This type also replaces the custom error type for `codespan-lsp`.
-There is now a [code of conduct](https://github.com/brendanzab/codespan/blob/master/CODE_OF_CONDUCT.md)
-and a [contributing guide](https://github.com/brendanzab/codespan/blob/master/CONTRIBUTING.md).
 
 ### Fixed
 

--- a/codespan-reporting/examples/custom_files.rs
+++ b/codespan-reporting/examples/custom_files.rs
@@ -30,7 +30,7 @@ fn main() -> anyhow::Result<()> {
     ];
 
     let writer = StandardStream::stderr(ColorChoice::Always);
-    let config = codespan_reporting::term::Config::default();
+    let config = term::Config::default();
     for message in &messages {
         let writer = &mut writer.lock();
         term::emit(writer, &config, &files, &message.to_diagnostic())?;
@@ -42,6 +42,7 @@ fn main() -> anyhow::Result<()> {
 /// A module containing the file implementation
 mod files {
     use codespan_reporting::files;
+    use codespan_reporting::term::RenderError;
     use std::ops::Range;
 
     /// A file that is backed by an `Arc<String>`.
@@ -56,13 +57,17 @@ mod files {
     }
 
     impl File {
-        fn line_start(&self, line_index: usize) -> Option<usize> {
+        fn line_start(&self, line_index: usize) -> Result<usize, RenderError> {
             use std::cmp::Ordering;
 
             match line_index.cmp(&self.line_starts.len()) {
-                Ordering::Less => self.line_starts.get(line_index).cloned(),
-                Ordering::Equal => Some(self.source.len()),
-                Ordering::Greater => None,
+                Ordering::Less => self
+                    .line_starts
+                    .get(line_index)
+                    .cloned()
+                    .ok_or(RenderError::InvalidIndex),
+                Ordering::Equal => Ok(self.source.len()),
+                Ordering::Greater => Err(RenderError::InvalidIndex),
             }
         }
     }
@@ -106,8 +111,10 @@ mod files {
         }
 
         /// Get the file corresponding to the given id.
-        fn get(&self, file_id: FileId) -> Option<&File> {
-            self.files.get(file_id.0 as usize)
+        fn get(&self, file_id: FileId) -> Result<&File, RenderError> {
+            self.files
+                .get(file_id.0 as usize)
+                .ok_or(RenderError::FileMissing)
         }
     }
 
@@ -116,27 +123,31 @@ mod files {
         type Name = &'files str;
         type Source = &'files str;
 
-        fn name(&self, file_id: FileId) -> Option<&str> {
-            Some(self.get(file_id)?.name.as_ref())
+        fn name(&self, file_id: FileId) -> Result<&str, RenderError> {
+            Ok(self.get(file_id)?.name.as_ref())
         }
 
-        fn source(&self, file_id: FileId) -> Option<&str> {
-            Some(&self.get(file_id)?.source)
+        fn source(&self, file_id: FileId) -> Result<&str, RenderError> {
+            Ok(&self.get(file_id)?.source)
         }
 
-        fn line_index(&self, file_id: FileId, byte_index: usize) -> Option<usize> {
-            match self.get(file_id)?.line_starts.binary_search(&byte_index) {
-                Ok(line) => Some(line),
-                Err(next_line) => Some(next_line - 1),
-            }
+        fn line_index(&self, file_id: FileId, byte_index: usize) -> Result<usize, RenderError> {
+            self.get(file_id)?
+                .line_starts
+                .binary_search(&byte_index)
+                .or_else(|next_line| Ok(next_line - 1))
         }
 
-        fn line_range(&self, file_id: FileId, line_index: usize) -> Option<Range<usize>> {
+        fn line_range(
+            &self,
+            file_id: FileId,
+            line_index: usize,
+        ) -> Result<Range<usize>, RenderError> {
             let file = self.get(file_id)?;
             let line_start = file.line_start(line_index)?;
             let next_line_start = file.line_start(line_index + 1)?;
 
-            Some(line_start..next_line_start)
+            Ok(line_start..next_line_start)
         }
     }
 }

--- a/codespan-reporting/src/term.rs
+++ b/codespan-reporting/src/term.rs
@@ -18,8 +18,11 @@ pub use self::config::{Chars, Config, DisplayStyle, Styles};
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum RenderError {
+    /// a required file is not in the file database
     FileMissing,
+    /// the file is present, but does not contain the specified index
     InvalidIndex,
+    /// There was a error while doing IO
     Io(std::io::Error),
 }
 
@@ -115,6 +118,11 @@ impl Into<ColorChoice> for ColorArg {
 }
 
 /// Emit a diagnostic using the given writer, context, config, and files.
+///
+/// The return value covers all error cases. These error case can arise if:
+/// * a file was removed from the file database.
+/// * a file was changed so that it is too small to have an index
+/// * IO fails
 pub fn emit<'files, F: Files<'files>>(
     writer: &mut dyn WriteColor,
     config: &Config,

--- a/codespan-reporting/src/term.rs
+++ b/codespan-reporting/src/term.rs
@@ -14,43 +14,6 @@ pub use termcolor;
 
 pub use self::config::{Chars, Config, DisplayStyle, Styles};
 
-/// An enum representing an error that happened while rendering a diagnostic.
-#[derive(Debug)]
-#[non_exhaustive]
-pub enum RenderError {
-    /// a required file is not in the file database
-    FileMissing,
-    /// the file is present, but does not contain the specified index
-    InvalidIndex,
-    /// There was a error while doing IO
-    Io(std::io::Error),
-}
-
-impl From<std::io::Error> for RenderError {
-    fn from(err: std::io::Error) -> RenderError {
-        RenderError::Io(err)
-    }
-}
-
-impl std::fmt::Display for RenderError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RenderError::FileMissing => write!(f, "file missing"),
-            RenderError::InvalidIndex => write!(f, "invalid index"),
-            RenderError::Io(err) => write!(f, "{}", err),
-        }
-    }
-}
-
-impl std::error::Error for RenderError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match &self {
-            RenderError::Io(err) => Some(err),
-            _ => None,
-        }
-    }
-}
-
 /// A command line argument that configures the coloring of the output.
 ///
 /// This can be used with command line argument parsers like [`clap`] or [`structopt`].
@@ -128,7 +91,7 @@ pub fn emit<'files, F: Files<'files>>(
     config: &Config,
     files: &'files F,
     diagnostic: &Diagnostic<F::FileId>,
-) -> Result<(), RenderError> {
+) -> Result<(), super::files::Error> {
     use self::renderer::Renderer;
     use self::views::{RichDiagnostic, ShortDiagnostic};
 

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -1,9 +1,9 @@
 use std::ops::Range;
 
 use crate::diagnostic::{Diagnostic, LabelStyle};
-use crate::files::{Files, Location};
+use crate::files::{Error, Files, Location};
 use crate::term::renderer::{Locus, MultiLabel, Renderer, SingleLabel};
-use crate::term::{Config, RenderError};
+use crate::term::Config;
 
 /// Count the number of decimal digits in `n`.
 fn count_digits(mut n: usize) -> usize {
@@ -36,7 +36,7 @@ where
         &self,
         files: &'files impl Files<'files, FileId = FileId>,
         renderer: &mut Renderer<'_, '_>,
-    ) -> Result<(), RenderError>
+    ) -> Result<(), Error>
     where
         FileId: 'files,
     {
@@ -426,7 +426,7 @@ where
         &self,
         files: &'files impl Files<'files, FileId = FileId>,
         renderer: &mut Renderer<'_, '_>,
-    ) -> Result<(), RenderError>
+    ) -> Result<(), Error>
     where
         FileId: 'files,
     {

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -87,24 +87,12 @@ where
 
         // Group labels by file
         for label in &self.diagnostic.labels {
-            let start_line_index = files
-                .line_index(label.file_id, label.range.start)
-                .ok_or(RenderError::InvalidIndex)?;
-            let start_line_number = files
-                .line_number(label.file_id, start_line_index)
-                .ok_or(RenderError::InvalidIndex)?;
-            let start_line_range = files
-                .line_range(label.file_id, start_line_index)
-                .ok_or(RenderError::InvalidIndex)?;
-            let end_line_index = files
-                .line_index(label.file_id, label.range.end)
-                .ok_or(RenderError::InvalidIndex)?;
-            let end_line_number = files
-                .line_number(label.file_id, end_line_index)
-                .ok_or(RenderError::InvalidIndex)?;
-            let end_line_range = files
-                .line_range(label.file_id, end_line_index)
-                .ok_or(RenderError::InvalidIndex)?;
+            let start_line_index = files.line_index(label.file_id, label.range.start)?;
+            let start_line_number = files.line_number(label.file_id, start_line_index)?;
+            let start_line_range = files.line_range(label.file_id, start_line_index)?;
+            let end_line_index = files.line_index(label.file_id, label.range.end)?;
+            let end_line_number = files.line_number(label.file_id, end_line_index)?;
+            let end_line_range = files.line_range(label.file_id, end_line_index)?;
 
             outer_padding = std::cmp::max(outer_padding, count_digits(start_line_number));
             outer_padding = std::cmp::max(outer_padding, count_digits(end_line_number));
@@ -124,9 +112,7 @@ where
                     {
                         // this label has a higher style or has the same style but starts earlier
                         labeled_file.start = label.range.start;
-                        labeled_file.location = files
-                            .location(label.file_id, label.range.start)
-                            .ok_or(RenderError::InvalidIndex)?;
+                        labeled_file.location = files.location(label.file_id, label.range.start)?;
                         labeled_file.max_label_style = label.style;
                     }
                     labeled_file
@@ -136,13 +122,8 @@ where
                     labeled_files.push(LabeledFile {
                         file_id: label.file_id,
                         start: label.range.start,
-                        name: files
-                            .name(label.file_id)
-                            .ok_or(RenderError::FileMissing)?
-                            .to_string(),
-                        location: files
-                            .location(label.file_id, label.range.start)
-                            .ok_or(RenderError::InvalidIndex)?,
+                        name: files.name(label.file_id)?.to_string(),
+                        location: files.location(label.file_id, label.range.start)?,
                         num_multi_labels: 0,
                         lines: BTreeMap::new(),
                         max_label_style: label.style,
@@ -237,12 +218,8 @@ where
                 // 7 │ │     _ 0 => "Buzz"
                 // ```
                 for line_index in (start_line_index + 1)..end_line_index {
-                    let line_range = files
-                        .line_range(label.file_id, line_index)
-                        .ok_or(RenderError::InvalidIndex)?;
-                    let line_number = files
-                        .line_number(label.file_id, line_index)
-                        .ok_or(RenderError::InvalidIndex)?;
+                    let line_range = files.line_range(label.file_id, line_index)?;
+                    let line_number = files.line_number(label.file_id, line_index)?;
 
                     outer_padding = std::cmp::max(outer_padding, count_digits(line_number));
 
@@ -308,9 +285,7 @@ where
         // ```
         let mut labeled_files = labeled_files.into_iter().peekable();
         while let Some(labeled_file) = labeled_files.next() {
-            let source = files
-                .source(labeled_file.file_id)
-                .ok_or(RenderError::FileMissing)?;
+            let source = files.source(labeled_file.file_id)?;
             let source = source.as_ref();
 
             // Top left border and locus.
@@ -371,12 +346,8 @@ where
 
                             renderer.render_snippet_source(
                                 outer_padding,
-                                files
-                                    .line_number(file_id, line_index + 1)
-                                    .ok_or(RenderError::InvalidIndex)?,
-                                &source[files
-                                    .line_range(file_id, line_index + 1)
-                                    .ok_or(RenderError::InvalidIndex)?],
+                                files.line_number(file_id, line_index + 1)?,
+                                &source[files.line_range(file_id, line_index + 1)?],
                                 self.diagnostic.severity,
                                 &[],
                                 labeled_file.num_multi_labels,
@@ -471,13 +442,8 @@ where
 
             renderer.render_header(
                 Some(&Locus {
-                    name: files
-                        .name(label.file_id)
-                        .ok_or(RenderError::FileMissing)?
-                        .to_string(),
-                    location: files
-                        .location(label.file_id, label.range.start)
-                        .ok_or(RenderError::InvalidIndex)?,
+                    name: files.name(label.file_id)?.to_string(),
+                    location: files.location(label.file_id, label.range.start)?,
                 }),
                 self.diagnostic.severity,
                 self.diagnostic.code.as_ref().map(String::as_str),

--- a/codespan/CHANGELOG.md
+++ b/codespan/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   This crate now depends on `codespan-reporting` non-optionally
+    because of the new error type.
+
 ### Fixed
 
 -   Building the crate on operating systems other than unix/windows

--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -11,10 +11,8 @@ documentation = "https://docs.rs/codespan"
 edition = "2018"
 
 [dependencies]
-codespan-reporting = { path = "../codespan-reporting", version = "0.9.5", optional = true }
+codespan-reporting = { path = "../codespan-reporting", version = "0.9.5" }
 serde = { version = "1", optional = true, features = ["derive"]}
 
 [features]
-default = ["reporting"]
-reporting = ["codespan-reporting"]
 serialization = ["serde", "codespan-reporting/serialization"]

--- a/codespan/src/file.rs
+++ b/codespan/src/file.rs
@@ -2,68 +2,9 @@
 use serde::{Deserialize, Serialize};
 use std::ffi::{OsStr, OsString};
 use std::num::NonZeroU32;
-use std::{error, fmt};
 
 use crate::{ByteIndex, ColumnIndex, LineIndex, LineOffset, Location, RawIndex, Span};
-
-#[derive(Debug, PartialEq)]
-pub struct LineIndexOutOfBoundsError {
-    pub given: LineIndex,
-    pub max: LineIndex,
-}
-
-impl error::Error for LineIndexOutOfBoundsError {}
-
-impl fmt::Display for LineIndexOutOfBoundsError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Line index out of bounds - given: {}, max: {}",
-            self.given, self.max
-        )
-    }
-}
-
-#[derive(Debug, PartialEq)]
-pub enum LocationError {
-    OutOfBounds { given: ByteIndex, span: Span },
-    InvalidCharBoundary { given: ByteIndex },
-}
-
-impl error::Error for LocationError {}
-
-impl fmt::Display for LocationError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            LocationError::OutOfBounds { given, span } => write!(
-                f,
-                "Byte index out of bounds - given: {}, span: {}",
-                given, span
-            ),
-            LocationError::InvalidCharBoundary { given } => {
-                write!(f, "Byte index within character boundary - given: {}", given)
-            }
-        }
-    }
-}
-
-#[derive(Debug, PartialEq)]
-pub struct SpanOutOfBoundsError {
-    pub given: Span,
-    pub span: Span,
-}
-
-impl error::Error for SpanOutOfBoundsError {}
-
-impl fmt::Display for SpanOutOfBoundsError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Span out of bounds - given: {}, span: {}",
-            self.given, self.span
-        )
-    }
-}
+use codespan_reporting::files::Error;
 
 /// A handle that points to a file in the database.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -165,34 +106,30 @@ where
     /// Get the span at the given line index.
     ///
     /// ```rust
-    /// use codespan::{Files, LineIndex, LineIndexOutOfBoundsError, Span};
+    /// use codespan::{Files, LineIndex, Span};
     ///
     /// let mut files = Files::new();
     /// let file_id = files.add("test", "foo\nbar\r\n\nbaz");
     ///
-    /// let line_sources = (0..5)
-    ///     .map(|line| files.line_span(file_id, line))
+    /// let line_sources = (0..4)
+    ///     .map(|line| files.line_span(file_id, line).unwrap())
     ///     .collect::<Vec<_>>();
     ///
-    /// assert_eq!(
-    ///     line_sources,
+    /// assert_eq!(line_sources,
     ///     [
-    ///         Ok(Span::new(0, 4)),    // 0: "foo\n"
-    ///         Ok(Span::new(4, 9)),    // 1: "bar\r\n"
-    ///         Ok(Span::new(9, 10)),   // 2: ""
-    ///         Ok(Span::new(10, 13)),  // 3: "baz"
-    ///         Err(LineIndexOutOfBoundsError {
-    ///             given: LineIndex::from(5),
-    ///             max: LineIndex::from(4),
-    ///         }),
+    ///         Span::new(0, 4),    // 0: "foo\n"
+    ///         Span::new(4, 9),    // 1: "bar\r\n"
+    ///         Span::new(9, 10),   // 2: ""
+    ///         Span::new(10, 13),  // 3: "baz"
     ///     ]
     /// );
+    /// assert!(files.line_span(file_id, 4).is_err());
     /// ```
     pub fn line_span(
         &self,
         file_id: FileId,
         line_index: impl Into<LineIndex>,
-    ) -> Result<Span, LineIndexOutOfBoundsError> {
+    ) -> Result<Span, Error> {
         self.get(file_id).line_span(line_index.into())
     }
 
@@ -217,28 +154,22 @@ where
     /// Get the location at the given byte index in the source file.
     ///
     /// ```rust
-    /// use codespan::{ByteIndex, Files, Location, LocationError, Span};
+    /// use codespan::{ByteIndex, Files, Location, Span};
     ///
     /// let mut files = Files::new();
     /// let file_id = files.add("test", "foo\nbar\r\n\nbaz");
     ///
-    /// assert_eq!(files.location(file_id, 0), Ok(Location::new(0, 0)));
-    /// assert_eq!(files.location(file_id, 7), Ok(Location::new(1, 3)));
-    /// assert_eq!(files.location(file_id, 8), Ok(Location::new(1, 4)));
-    /// assert_eq!(files.location(file_id, 9), Ok(Location::new(2, 0)));
-    /// assert_eq!(
-    ///     files.location(file_id, 100),
-    ///     Err(LocationError::OutOfBounds {
-    ///         given: ByteIndex::from(100),
-    ///         span: Span::new(0, 13),
-    ///     }),
-    /// );
+    /// assert_eq!(files.location(file_id, 0).unwrap(), Location::new(0, 0));
+    /// assert_eq!(files.location(file_id, 7).unwrap(), Location::new(1, 3));
+    /// assert_eq!(files.location(file_id, 8).unwrap(), Location::new(1, 4));
+    /// assert_eq!(files.location(file_id, 9).unwrap(), Location::new(2, 0));
+    /// assert!(files.location(file_id, 100).is_err());
     /// ```
     pub fn location(
         &self,
         file_id: FileId,
         byte_index: impl Into<ByteIndex>,
-    ) -> Result<Location, LocationError> {
+    ) -> Result<Location, Error> {
         self.get(file_id).location(byte_index.into())
     }
 
@@ -282,14 +213,10 @@ where
     /// let mut files = Files::new();
     /// let file_id = files.add("test",  "hello world!");
     ///
-    /// assert_eq!(files.source_slice(file_id, Span::new(0, 5)), Ok("hello"));
+    /// assert_eq!(files.source_slice(file_id, Span::new(0, 5)).unwrap(), "hello");
     /// assert!(files.source_slice(file_id, Span::new(0, 100)).is_err());
     /// ```
-    pub fn source_slice(
-        &self,
-        file_id: FileId,
-        span: impl Into<Span>,
-    ) -> Result<&str, SpanOutOfBoundsError> {
+    pub fn source_slice(&self, file_id: FileId, span: impl Into<Span>) -> Result<&str, Error> {
         self.get(file_id).source_slice(span.into())
     }
 }
@@ -303,24 +230,28 @@ where
     type Name = String;
     type Source = &'a str;
 
-    fn name(&self, id: FileId) -> Option<String> {
+    fn name(&self, id: FileId) -> Result<String, Error> {
         use std::path::PathBuf;
 
-        Some(PathBuf::from(self.name(id)).display().to_string())
+        Ok(PathBuf::from(self.name(id)).display().to_string())
     }
 
-    fn source(&'a self, id: FileId) -> Option<&str> {
-        Some(self.source(id).as_ref())
+    fn source(&'a self, id: FileId) -> Result<&str, Error> {
+        Ok(self.source(id).as_ref())
     }
 
-    fn line_index(&self, id: FileId, byte_index: usize) -> Option<usize> {
-        Some(self.line_index(id, byte_index as u32).to_usize())
+    fn line_index(&self, id: FileId, byte_index: usize) -> Result<usize, Error> {
+        Ok(self.line_index(id, byte_index as u32).to_usize())
     }
 
-    fn line_range(&'a self, id: FileId, line_index: usize) -> Option<std::ops::Range<usize>> {
-        let span = self.line_span(id, line_index as u32).ok()?;
+    fn line_range(
+        &'a self,
+        id: FileId,
+        line_index: usize,
+    ) -> Result<std::ops::Range<usize>, Error> {
+        let span = self.line_span(id, line_index as u32)?;
 
-        Some(span.start().to_usize()..span.end().to_usize())
+        Ok(span.start().to_usize()..span.end().to_usize())
     }
 }
 
@@ -368,15 +299,15 @@ where
         &self.name
     }
 
-    fn line_start(&self, line_index: LineIndex) -> Result<ByteIndex, LineIndexOutOfBoundsError> {
+    fn line_start(&self, line_index: LineIndex) -> Result<ByteIndex, Error> {
         use std::cmp::Ordering;
 
         match line_index.cmp(&self.last_line_index()) {
             Ordering::Less => Ok(self.line_starts[line_index.to_usize()]),
             Ordering::Equal => Ok(self.source_span().end()),
-            Ordering::Greater => Err(LineIndexOutOfBoundsError {
-                given: line_index,
-                max: self.last_line_index(),
+            Ordering::Greater => Err(Error::LineTooLarge {
+                given: line_index.to_usize(),
+                max: self.last_line_index().to_usize(),
             }),
         }
     }
@@ -385,7 +316,7 @@ where
         LineIndex::from(self.line_starts.len() as RawIndex)
     }
 
-    fn line_span(&self, line_index: LineIndex) -> Result<Span, LineIndexOutOfBoundsError> {
+    fn line_span(&self, line_index: LineIndex) -> Result<Span, Error> {
         let line_start = self.line_start(line_index)?;
         let next_line_start = self.line_start(line_index + LineOffset::from(1))?;
 
@@ -400,25 +331,25 @@ where
         }
     }
 
-    fn location(&self, byte_index: ByteIndex) -> Result<Location, LocationError> {
+    fn location(&self, byte_index: ByteIndex) -> Result<Location, Error> {
         let line_index = self.line_index(byte_index);
-        let line_start_index =
-            self.line_start(line_index)
-                .map_err(|_| LocationError::OutOfBounds {
-                    given: byte_index,
-                    span: self.source_span(),
-                })?;
+        let line_start_index = self
+            .line_start(line_index)
+            .map_err(|_| Error::IndexTooLarge {
+                given: byte_index.to_usize(),
+                max: self.source().as_ref().len() - 1,
+            })?;
         let line_src = self
             .source
             .as_ref()
             .get(line_start_index.to_usize()..byte_index.to_usize())
             .ok_or_else(|| {
-                let given = byte_index;
-                if given >= self.source_span().end() {
-                    let span = self.source_span();
-                    LocationError::OutOfBounds { given, span }
+                let given = byte_index.to_usize();
+                let max = self.source().as_ref().len() - 1;
+                if given > max {
+                    Error::IndexTooLarge { given, max }
                 } else {
-                    LocationError::InvalidCharBoundary { given }
+                    Error::InvalidCharBoundary { given }
                 }
             })?;
 
@@ -436,13 +367,16 @@ where
         Span::from_str(self.source.as_ref())
     }
 
-    fn source_slice(&self, span: Span) -> Result<&str, SpanOutOfBoundsError> {
+    fn source_slice(&self, span: Span) -> Result<&str, Error> {
         let start = span.start().to_usize();
         let end = span.end().to_usize();
 
         self.source.as_ref().get(start..end).ok_or_else(|| {
-            let span = Span::from_str(self.source.as_ref());
-            SpanOutOfBoundsError { given: span, span }
+            let max = self.source().as_ref().len() - 1;
+            Error::IndexTooLarge {
+                given: if start > max { start } else { end },
+                max,
+            }
         })
     }
 }
@@ -485,13 +419,13 @@ mod test {
         let line_sources = (0..4)
             .map(|line| {
                 let line_span = files.line_span(file_id, line).unwrap();
-                files.source_slice(file_id, line_span)
+                files.source_slice(file_id, line_span).unwrap()
             })
             .collect::<Vec<_>>();
 
         assert_eq!(
             line_sources,
-            [Ok("foo\n"), Ok("bar\r\n"), Ok("\n"), Ok("baz")],
+            ["foo\n", "bar\r\n", "\n", "baz"],
         );
     }
 }

--- a/codespan/src/lib.rs
+++ b/codespan/src/lib.rs
@@ -15,7 +15,6 @@ mod location;
 mod span;
 
 pub use crate::file::{FileId, Files};
-pub use crate::file::{LineIndexOutOfBoundsError, LocationError, SpanOutOfBoundsError};
 pub use crate::index::{ByteIndex, ByteOffset};
 pub use crate::index::{ColumnIndex, ColumnNumber, ColumnOffset};
 pub use crate::index::{Index, Offset};


### PR DESCRIPTION
This unifies the `codespan-lsp` type and errors from codespan into one type that is also not as fragmented. As far as I could tell, these specific structs are not required by some lsp stuff, but please correct me if I'm wrong.

This also replaces many `Option`s in the `Files` implementation by `Result`s.

As discussed in the matrix room a little while back (cf. <https://matrix.to/#/!oaTjvHZyVsPimZCAoK:matrix.org/$Dgf8MwidQ3YMZ2hSD_PnN-aVVYhKaNY_dK5Rr3x3tCU?via=matrix.org> or view chat starting on 2020-09-17T18:39Z), this is required to accurately report errors in `term::emit`.