### PR TITLE
Release v0.11.0

### DIFF
--- a/codespan-lsp/CHANGELOG.md
+++ b/codespan-lsp/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2020-11-30
+
+There is now a [code of conduct](https://github.com/brendanzab/codespan/blob/master/CODE_OF_CONDUCT.md)
+and a [contributing guide](https://github.com/brendanzab/codespan/blob/master/CONTRIBUTING.md).
+
 ### Changed
 
 -   The error type in `codespan-lsp` is replaced with the error type in the `codespan-reporting` crate.
@@ -68,7 +73,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1] - 2019-02-26
 ## [0.2.0] - 2018-10-11
 
-[Unreleased]: https://github.com/brendanzab/codespan/compare/v0.10.1...HEAD
+[Unreleased]: https://github.com/brendanzab/codespan/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/brendanzab/codespan/compare/v0.10.1..v0.11.0
 [0.10.1]: https://github.com/brendanzab/codespan/compare/v0.10.0..v0.10.1
 [0.10.0]: https://github.com/brendanzab/codespan/compare/v0.9.5...v0.10.0
 [0.9.5]: https://github.com/brendanzab/codespan/compare/v0.9.4...v0.9.5

--- a/codespan-lsp/Cargo.toml
+++ b/codespan-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codespan-lsp"
-version = "0.10.2-alpha.0"
+version = "0.11.0"
 license = "Apache-2.0"
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 description = "Conversions between codespan types and Language Server Protocol types"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/codespan-lsp"
 edition = "2018"
 
 [dependencies]
-codespan-reporting = { version = "0.9.5", path = "../codespan-reporting" }
+codespan-reporting = { version = "0.11.0", path = "../codespan-reporting" }
 # WARNING: Be extremely careful when expanding this version range.
 # We should be confident that all of the uses of `lsp-types` in `codespan-lsp`
 # will be valid for all the versions in this range. Getting this range wrong

--- a/codespan-reporting/CHANGELOG.md
+++ b/codespan-reporting/CHANGELOG.md
@@ -17,6 +17,7 @@ and a [contributing guide](https://github.com/brendanzab/codespan/blob/master/CO
 -   There is now a custom error type.
 -   There now is a medium rendering mode that is like the short rendering mode
     but also shows notes from the diagnostic.
+-   `PartialEq` and `Eq` implementations for the `diagnostic::{Diagnostic, Label, Severity}` types.
 
 ### Changed
 

--- a/codespan-reporting/CHANGELOG.md
+++ b/codespan-reporting/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2020-11-30
+
 There is now a [code of conduct](https://github.com/brendanzab/codespan/blob/master/CODE_OF_CONDUCT.md)
 and a [contributing guide](https://github.com/brendanzab/codespan/blob/master/CONTRIBUTING.md).
+
+Some versions were skipped to sync up with the `codespan-lsp` crate. The release
+process has been changed so this should not happen again.
 
 ### Added
 
@@ -315,8 +320,9 @@ and a [contributing guide](https://github.com/brendanzab/codespan/blob/master/CO
 ## [0.2.1] - 2019-02-26
 ## [0.2.0] - 2018-10-11
 
-[Unreleased]: https://github.com/brendanzab/codespan/compare/v0.9.5...HEAD
-[0.9.4]: https://github.com/brendanzab/codespan/compare/v0.9.4...v0.9.5
+[Unreleased]: https://github.com/brendanzab/codespan/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/brendanzab/codespan/compare/v0.9.5...v0.11.0
+[0.9.5]: https://github.com/brendanzab/codespan/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/brendanzab/codespan/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/brendanzab/codespan/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/brendanzab/codespan/compare/v0.9.1...v0.9.2

--- a/codespan-reporting/Cargo.toml
+++ b/codespan-reporting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codespan-reporting"
-version = "0.9.5"
+version = "0.11.0"
 readme = "../README.md"
 license = "Apache-2.0"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>"]

--- a/codespan-reporting/src/diagnostic.rs
+++ b/codespan-reporting/src/diagnostic.rs
@@ -16,7 +16,7 @@ use std::ops::Range;
 /// assert!(Severity::Warning > Severity::Note);
 /// assert!(Severity::Note > Severity::Help);
 /// ```
-#[derive(Copy, Clone, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub enum Severity {
     /// An unexpected bug.
@@ -60,7 +60,7 @@ pub enum LabelStyle {
 }
 
 /// A label describing an underlined region of code associated with a diagnostic.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct Label<FileId> {
     /// The style of the label.
@@ -114,7 +114,7 @@ impl<FileId> Label<FileId> {
 /// warnings to the user.
 ///
 /// The position of a Diagnostic is considered to be the position of the [`Label`] that has the earliest starting position and has the highest style which appears in all the labels of the diagnostic.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct Diagnostic<FileId> {
     /// The overall severity of the diagnostic

--- a/codespan/CHANGELOG.md
+++ b/codespan/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2020-11-30
+
+There is now a [code of conduct](https://github.com/brendanzab/codespan/blob/master/CODE_OF_CONDUCT.md)
+and a [contributing guide](https://github.com/brendanzab/codespan/blob/master/CONTRIBUTING.md).
+
+Some versions were skipped to sync up with the `codespan-lsp` crate. The release
+process has been changed so this should not happen again.
+
 ### Changed
 
 -   This crate now depends on `codespan-reporting` non-optionally
@@ -51,8 +59,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1] - 2019-02-26
 ## [0.2.0] - 2018-10-11
 
-[Unreleased]: https://github.com/brendanzab/codespan/compare/v0.9.5...HEAD
-[0.9.4]: https://github.com/brendanzab/codespan/compare/v0.9.4...v0.9.5
+[Unreleased]: https://github.com/brendanzab/codespan/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/brendanzab/codespan/compare/v0.9.5...v0.11.0
+[0.9.5]: https://github.com/brendanzab/codespan/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/brendanzab/codespan/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/brendanzab/codespan/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/brendanzab/codespan/compare/v0.9.1...v0.9.2

--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codespan"
-version = "0.9.5"
+version = "0.11.0"
 readme = "README.md"
 license = "Apache-2.0"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>"]
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/codespan"
 edition = "2018"
 
 [dependencies]
-codespan-reporting = { path = "../codespan-reporting", version = "0.9.5" }
+codespan-reporting = { path = "../codespan-reporting", version = "0.11.0" }
 serde = { version = "1", optional = true, features = ["derive"]}
 
 [features]


### PR DESCRIPTION
We've skipped some versions for `codespan-reporting` and `codespan` to get the crate versions back in sync with `codespan-lsp`.

Closes #298.