### PR TITLE
make Diagnostic documentation & methods clearer

### DIFF
--- a/codespan-reporting/src/diagnostic.rs
+++ b/codespan-reporting/src/diagnostic.rs
@@ -183,27 +183,27 @@ impl<FileId> Diagnostic<FileId> {
         Diagnostic::new(Severity::Help)
     }
 
-    /// Add an error code to the diagnostic.
+    /// Set the error code of the diagnostic.
     pub fn with_code(mut self, code: impl Into<String>) -> Diagnostic<FileId> {
         self.code = Some(code.into());
         self
     }
 
-    /// Add a message to the diagnostic.
+    /// Set the message of the diagnostic.
     pub fn with_message(mut self, message: impl Into<String>) -> Diagnostic<FileId> {
         self.message = message.into();
         self
     }
 
     /// Add some labels to the diagnostic.
-    pub fn with_labels(mut self, labels: Vec<Label<FileId>>) -> Diagnostic<FileId> {
-        self.labels = labels;
+    pub fn with_labels(mut self, mut labels: Vec<Label<FileId>>) -> Diagnostic<FileId> {
+        self.labels.append(&mut labels);
         self
     }
 
     /// Add some notes to the diagnostic.
-    pub fn with_notes(mut self, notes: Vec<String>) -> Diagnostic<FileId> {
-        self.notes = notes;
+    pub fn with_notes(mut self, mut notes: Vec<String>) -> Diagnostic<FileId> {
+        self.notes.append(&mut notes);
         self
     }
 }


### PR DESCRIPTION
The documentation of `with_message` and `with_labels` was confusing and sounded like it would add labels or notes but it replaced the whole Vec. So changed the code in these two functions to append to the Vec instead, which makes more sense to me.
I did not use `extend` as proposed on Matrix originally because that makes copies while `append` moves the elements. This requires that the parameters be `mut`.

For the other functions the documentation has been changed to be more precise that they replace values if set before.