### PR TITLE
Forbid unsafe code

### DIFF
--- a/codespan-lsp/src/lib.rs
+++ b/codespan-lsp/src/lib.rs
@@ -1,5 +1,7 @@
 //! Utilities for translating from codespan types into Language Server Protocol (LSP) types
 
+#![forbid(unsafe_code)]
+
 use std::ops::Range;
 
 use codespan_reporting::files::{Error, Files};

--- a/codespan-reporting/src/lib.rs
+++ b/codespan-reporting/src/lib.rs
@@ -1,5 +1,7 @@
 //! Diagnostic reporting support for the codespan crate.
 
+#![forbid(unsafe_code)]
+
 pub mod diagnostic;
 pub mod files;
 pub mod term;

--- a/codespan/src/lib.rs
+++ b/codespan/src/lib.rs
@@ -9,6 +9,8 @@
 //! - **serialization** - Adds `Serialize` and `Deserialize` implementations
 //!   for use with `serde`
 
+#![forbid(unsafe_code)]
+
 mod file;
 mod index;
 mod location;


### PR DESCRIPTION
No unsafe code seems to be needed, so we can get a green line in [cargo-geiger](https://github.com/rust-secure-code/cargo-geiger) with `#![forbid(unsafe_code)]`.