### PR TITLE
Change multiline rendering with breaks to work properly

### DIFF
--- a/codespan-reporting/CHANGELOG.md
+++ b/codespan-reporting/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   Broken lines are now rendered properly with multiline spans.
+
+    We used to render the wrong lines in the gutter when there were multiline spans
+    and there were breaks in the file.
+
+    <details>
+    <summary>Example</summary>
+
+    Before:
+
+    ```text
+    error[0001]: oh noes, a cupcake has occurred!
+       ┌─ test:4:1
+       │
+     4 │   ╭ Cupcake ipsum dolor. Sit amet marshmallow topping cheesecake
+     5 │   │ muffin. Halvah croissant candy canes bonbon candy. Apple pie jelly
+       │ ╭─│─────────'
+       ·   │
+    10 │ │ │ Muffin danish chocolate soufflé pastry icing bonbon oat cake.
+    11 │ │ │ Powder cake jujubes oat cake. Lemon drops tootsie roll marshmallow
+       │ │ ╰─────────────────────────────' blah blah
+       · │ │
+    19 │ │   soufflé marzipan. Chocolate bar oat cake jujubes lollipop pastry
+    20 │ │   cupcake. Candy canes cupcake toffee gingerbread candy canes muffin
+       │ ╰──────────' blah blah
+    ```
+
+    After:
+
+    ```text
+    error[0001]: oh noes, a cupcake has occurred!
+       ┌─ test:4:1
+       │
+     4 │   ╭ Cupcake ipsum dolor. Sit amet marshmallow topping cheesecake
+     5 │   │ muffin. Halvah croissant candy canes bonbon candy. Apple pie jelly
+       │ ╭─│─────────'
+       · │ │
+    10 │ │ │ Muffin danish chocolate soufflé pastry icing bonbon oat cake.
+    11 │ │ │ Powder cake jujubes oat cake. Lemon drops tootsie roll marshmallow
+       │ │ ╰─────────────────────────────' blah blah
+       · │
+    19 │ │   soufflé marzipan. Chocolate bar oat cake jujubes lollipop pastry
+    20 │ │   cupcake. Candy canes cupcake toffee gingerbread candy canes muffin
+       │ ╰──────────' blah blah
+    ```
+
+    </details>
+
 ## [0.11.1] - 2021-01-18
 
 ### Added

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -324,7 +324,7 @@ where
 
                 // Check to see if we need to render any intermediate stuff
                 // before rendering the next line.
-                if let Some((next_line_index, _)) = lines.peek() {
+                if let Some((next_line_index, next_line)) = lines.peek() {
                     match next_line_index.checked_sub(*line_index) {
                         // Consecutive lines
                         Some(1) => {}
@@ -361,7 +361,7 @@ where
                                 outer_padding,
                                 self.diagnostic.severity,
                                 labeled_file.num_multi_labels,
-                                &line.multi_labels,
+                                &next_line.multi_labels,
                             )?;
                         }
                     }


### PR DESCRIPTION
I ran into this when trying to replicate the example showing what all the parts were

<details>
<summary>Example</summary>
Before:

```text
error[0001]: oh noes, a cupcake has occurred!
   ┌─ test:4:1
   │
 4 │   ╭ Cupcake ipsum dolor. Sit amet marshmallow topping cheesecake
 5 │   │ muffin. Halvah croissant candy canes bonbon candy. Apple pie jelly
   │ ╭─│─────────'
   ·   │
10 │ │ │ Muffin danish chocolate soufflé pastry icing bonbon oat cake.
11 │ │ │ Powder cake jujubes oat cake. Lemon drops tootsie roll marshmallow
   │ │ ╰─────────────────────────────' blah blah
   · │ │
19 │ │   soufflé marzipan. Chocolate bar oat cake jujubes lollipop pastry
20 │ │   cupcake. Candy canes cupcake toffee gingerbread candy canes muffin
   │ ╰──────────' blah blah
```

After:

```text
error[0001]: oh noes, a cupcake has occurred!
   ┌─ test:4:1
   │
 4 │   ╭ Cupcake ipsum dolor. Sit amet marshmallow topping cheesecake
 5 │   │ muffin. Halvah croissant candy canes bonbon candy. Apple pie jelly
   │ ╭─│─────────'
   · │ │
10 │ │ │ Muffin danish chocolate soufflé pastry icing bonbon oat cake.
11 │ │ │ Powder cake jujubes oat cake. Lemon drops tootsie roll marshmallow
   │ │ ╰─────────────────────────────' blah blah
   · │
19 │ │   soufflé marzipan. Chocolate bar oat cake jujubes lollipop pastry
20 │ │   cupcake. Candy canes cupcake toffee gingerbread candy canes muffin
   │ ╰──────────' blah blah
```
</details>