### PR TITLE
Allow ?Sized implementations of `Files` for `term::emit`.

### DIFF
--- a/codespan-reporting/src/term.rs
+++ b/codespan-reporting/src/term.rs
@@ -84,7 +84,7 @@ impl From<ColorArg> for ColorChoice {
 /// * a file was removed from the file database.
 /// * a file was changed so that it is too small to have an index
 /// * IO fails
-pub fn emit<'files, F: Files<'files>>(
+pub fn emit<'files, F: Files<'files> + ?Sized>(
     writer: &mut dyn WriteColor,
     config: &Config,
     files: &'files F,

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -32,7 +32,7 @@ where
 
     pub fn render<'files>(
         &self,
-        files: &'files impl Files<'files, FileId = FileId>,
+        files: &'files (impl Files<'files, FileId = FileId> + ?Sized),
         renderer: &mut Renderer<'_, '_>,
     ) -> Result<(), Error>
     where
@@ -455,7 +455,7 @@ where
 
     pub fn render<'files>(
         &self,
-        files: &'files impl Files<'files, FileId = FileId>,
+        files: &'files (impl Files<'files, FileId = FileId> + ?Sized),
         renderer: &mut Renderer<'_, '_>,
     ) -> Result<(), Error>
     where

--- a/codespan/src/file.rs
+++ b/codespan/src/file.rs
@@ -235,7 +235,7 @@ where
         Ok(PathBuf::from(self.name(id)).display().to_string())
     }
 
-    fn source(&'a self, id: FileId) -> Result<&str, Error> {
+    fn source(&'a self, id: FileId) -> Result<&'a str, Error> {
         Ok(self.source(id).as_ref())
     }
 


### PR DESCRIPTION
`term::emit` can work with `?Sized` implementations of `Files` (e.g. `dyn Trait`), but it lacked the `?Sized` bound.