### PR TITLE
Add Spade to list of README projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,17 +113,19 @@ More examples of using `codespan-reporting` can be found in the
 
 `codespan-reporting` is currently used in the following projects:
 
-- [Arret](https://arret-lang.org)
 - [cargo-deny](https://github.com/EmbarkStudios/cargo-deny)
+- [cargo-about](https://github.com/EmbarkStudios/cargo-about)
 - [CXX](https://github.com/dtolnay/cxx)
-- [Gleam](https://github.com/lpil/gleam/)
+- [full_moon](https://github.com/Kampfkarren/full-moon)
+- [Gleam](https://github.com/gleam-lang/gleam)
 - [Gluon](https://github.com/gluon-lang/gluon)
 - [MDBook LinkCheck](https://github.com/Michael-F-Bryan/mdbook-linkcheck)
 - [mos](https://github.com/datatrash/mos)
-- [Nushell](https://www.nushell.sh/)
 - [Pikelet](https://github.com/pikelet-lang/pikelet)
-- [Naga](https://github.com/gfx-rs/naga)
-- [Spade](https://gitlab.com/spade-lang/spade), a better hardware description language.
+- [Naga](https://github.com/gfx-rs/wgpu/tree/trunk/naga)
+- [Spade](https://gitlab.com/spade-lang/spade)
+ 
+ ... [any many more](https://crates.io/crates/codespan-reporting/reverse_dependencies)
 
 ## Alternatives to codespan-reporting
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ More examples of using `codespan-reporting` can be found in the
 - [Nushell](https://www.nushell.sh/)
 - [Pikelet](https://github.com/pikelet-lang/pikelet)
 - [Naga](https://github.com/gfx-rs/naga)
+- [Spade](https://gitlab.com/spade-lang/spade), a better hardware description language.
 
 ## Alternatives to codespan-reporting
 


### PR DESCRIPTION
# Content

This PR adds a new project under the list of projects using this crate ([proof of usage](https://gitlab.com/spade-lang/spade/-/blob/main/Cargo.toml?ref_type=heads#L22)). I can remove the brief description (copied from the repository's description) if deemed necessary,

# Files changed

- `README.md`: one line added

# Misc

- [x] I've read the [contribution guidelines](https://github.com/brendanzab/codespan/blob/master/CONTRIBUTING.md)
- [x] I've read the [code of conduct](https://github.com/brendanzab/codespan/blob/master/CODE_OF_CONDUCT.md)