### PR TITLE
unicode-width: allow 0.2 to be selected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,9 +576,9 @@ checksum = "a8083c594e02b8ae1654ae26f0ade5158b119bd88ad0e8227a5d8fcd72407946"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.4"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"

--- a/codespan-reporting/Cargo.toml
+++ b/codespan-reporting/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "1", optional = true, features = ["derive"] }
 termcolor = "1.0.4"
-unicode-width = "0.1"
+unicode-width = ">=0.1,<0.3"
 
 [dev-dependencies]
 anyhow = "1"


### PR DESCRIPTION
Although the lockfile remains locked to 0.1.14 in this project as there are many other dependencies (e.g. rustyline) which depends on ^0.1, but for dependents on `codespan-reporting` specifically it allows to update to 0.2 without duplicating dependencies. 