### PR TITLE
Add `no_std` Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: ["1.46.0", "stable", "beta", "nightly"]
+        rust: ["1.67.0", "stable", "beta", "nightly"]
     name: Check (${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: ["1.46.0", "stable", "beta", "nightly"]
+        rust: ["1.67.0", "stable", "beta", "nightly"]
     name: Test Suite (${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v2
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: ["1.46.0", "stable", "beta", "nightly"]
+        rust: ["1.67.0", "stable", "beta", "nightly"]
     name: Rustfmt (${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,32 @@ jobs:
           command: check
           args: --manifest-path "codespan-lsp/Cargo.toml"
 
+  check-no-std:
+    name: Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - ["1.82.0", "stable", "beta", "nightly"]
+        target:
+          - ["x86_64-unknown-none", "wasm32v1-none", "thumbv6m-none-eabi"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
+      - name: Run cargo check for codespan-reporting
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path "codespan-reporting/Cargo.toml" --no-default-features --features "serialization" --target ${{ matrix.target }}
+      - name: Run cargo check for codespan
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path "codespan/Cargo.toml" --no-default-features --features "serialization" --target ${{ matrix.target }}
+
   test:
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         rust: 
-          - "1.82.0"
+          - "1.84.0"
           - "stable"
           - "beta"
           - "nightly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rust: 
           - "1.84.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust:
-          - ["1.82.0", "stable", "beta", "nightly"]
+        rust: 
+          - "1.82.0"
+          - "stable"
+          - "beta"
+          - "nightly"
         target:
-          - ["x86_64-unknown-none", "wasm32v1-none", "thumbv6m-none-eabi"]
+          - "x86_64-unknown-none"
+          - "wasm32v1-none"
+          - "thumbv6m-none-eabi"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ members = [
     "./codespan-reporting",
     "./codespan-lsp",
 ]
+resolver = "2"

--- a/codespan-lsp/CHANGELOG.md
+++ b/codespan-lsp/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-The minimum supported rustc version is now `1.46.0` (was `1.40.0`).
+The minimum supported rustc version is now `1.67.0` (was `1.40.0`).
 This is because some dependencies now require this Rust version.
 
 ### Changed

--- a/codespan-lsp/Cargo.toml
+++ b/codespan-lsp/Cargo.toml
@@ -10,7 +10,10 @@ documentation = "https://docs.rs/codespan-lsp"
 edition = "2021"
 
 [dependencies]
-codespan-reporting = { version = "0.11.1", path = "../codespan-reporting" }
+codespan-reporting = { version = "0.11.1", path = "../codespan-reporting", features = [
+  "std",
+  "termcolor",
+] }
 # WARNING: Be extremely careful when expanding this version range.
 # We should be confident that all of the uses of `lsp-types` in `codespan-lsp`
 # will be valid for all the versions in this range. Getting this range wrong

--- a/codespan-lsp/Cargo.toml
+++ b/codespan-lsp/Cargo.toml
@@ -24,6 +24,11 @@ lsp-types = ">=0.84, <0.92"
 url = "2"
 
 [lints.clippy]
+# Certain items from `core` are re-exported in `alloc` and `std`, and likewise `alloc` has items
+# re-exported in `std`.
+# `core` is available on all platforms, `alloc` is available on almost all, and `std` is only
+# available on some.
+# These lints ensure we don't import from a "less available" crate without reason.
 alloc_instead_of_core = "warn"
 std_instead_of_alloc = "warn"
 std_instead_of_core = "warn"

--- a/codespan-lsp/Cargo.toml
+++ b/codespan-lsp/Cargo.toml
@@ -18,3 +18,8 @@ codespan-reporting = { version = "0.11.1", path = "../codespan-reporting" }
 # absolute no-no, breaking much of what we enjoy about Cargo!
 lsp-types = ">=0.84, <0.92"
 url = "2"
+
+[lints.clippy]
+alloc_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"

--- a/codespan-lsp/Cargo.toml
+++ b/codespan-lsp/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/brendanzab/codespan"
 repository = "https://github.com/brendanzab/codespan"
 documentation = "https://docs.rs/codespan-lsp"
 edition = "2021"
+rust-version = "1.67"
 
 [dependencies]
 codespan-reporting = { version = "0.11.1", path = "../codespan-reporting", features = [

--- a/codespan-lsp/Cargo.toml
+++ b/codespan-lsp/Cargo.toml
@@ -7,7 +7,7 @@ description = "Conversions between codespan types and Language Server Protocol t
 homepage = "https://github.com/brendanzab/codespan"
 repository = "https://github.com/brendanzab/codespan"
 documentation = "https://docs.rs/codespan-lsp"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 codespan-reporting = { version = "0.11.1", path = "../codespan-reporting" }

--- a/codespan-lsp/src/lib.rs
+++ b/codespan-lsp/src/lib.rs
@@ -1,8 +1,12 @@
 //! Utilities for translating from codespan types into Language Server Protocol (LSP) types
 
 #![forbid(unsafe_code)]
+#![no_std]
 
-use std::ops::Range;
+#[cfg(test)]
+extern crate alloc;
+
+use core::ops::Range;
 
 use codespan_reporting::files::{Error, Files};
 
@@ -139,6 +143,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use codespan_reporting::files::{Location, SimpleFiles};
 
     use super::*;

--- a/codespan-reporting/CHANGELOG.md
+++ b/codespan-reporting/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-The minimum supported rustc version is now `1.46.0` (was `1.40.0`).
-This is because some testing dependencies now require this Rust version.
+The minimum supported rustc version is now `1.67.0` (was `1.40.0`).
+This is because some dependencies now require this Rust version.
 
 ### Added
 

--- a/codespan-reporting/Cargo.toml
+++ b/codespan-reporting/Cargo.toml
@@ -12,8 +12,8 @@ exclude = ["assets/**"]
 edition = "2021"
 
 [dependencies]
-serde = { version = "1", optional = true, features = ["derive"] }
-termcolor = "1.0.4"
+serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }
+termcolor = { version = "1.0.4", optional = true }
 unicode-width = ">=0.1,<0.3"
 
 [dev-dependencies]
@@ -26,6 +26,9 @@ rustyline = "6"
 unindent = "0.1"
 
 [features]
+default = ["std", "termcolor"]
+std = ["serde?/std"]
+termcolor = ["std", "dep:termcolor"]
 serialization = ["serde", "serde/rc"]
 ascii-only = []
 

--- a/codespan-reporting/Cargo.toml
+++ b/codespan-reporting/Cargo.toml
@@ -34,6 +34,11 @@ serialization = ["serde", "serde/rc"]
 ascii-only = []
 
 [lints.clippy]
+# Certain items from `core` are re-exported in `alloc` and `std`, and likewise `alloc` has items
+# re-exported in `std`.
+# `core` is available on all platforms, `alloc` is available on almost all, and `std` is only
+# available on some.
+# These lints ensure we don't import from a "less available" crate without reason.
 alloc_instead_of_core = "warn"
 std_instead_of_alloc = "warn"
 std_instead_of_core = "warn"

--- a/codespan-reporting/Cargo.toml
+++ b/codespan-reporting/Cargo.toml
@@ -30,7 +30,7 @@ unindent = "0.1"
 default = ["std", "termcolor"]
 std = ["serde?/std"]
 termcolor = ["std", "dep:termcolor"]
-serialization = ["serde", "serde/rc"]
+serialization = ["serde"]
 ascii-only = []
 
 [lints.clippy]

--- a/codespan-reporting/Cargo.toml
+++ b/codespan-reporting/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/brendanzab/codespan"
 documentation = "https://docs.rs/codespan-reporting"
 exclude = ["assets/**"]
 edition = "2021"
+rust-version = "1.67"
 
 [dependencies]
 serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"] }

--- a/codespan-reporting/Cargo.toml
+++ b/codespan-reporting/Cargo.toml
@@ -28,3 +28,8 @@ unindent = "0.1"
 [features]
 serialization = ["serde", "serde/rc"]
 ascii-only = []
+
+[lints.clippy]
+alloc_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"

--- a/codespan-reporting/Cargo.toml
+++ b/codespan-reporting/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/brendanzab/codespan"
 repository = "https://github.com/brendanzab/codespan"
 documentation = "https://docs.rs/codespan-reporting"
 exclude = ["assets/**"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 serde = { version = "1", optional = true, features = ["derive"] }

--- a/codespan-reporting/examples/custom_files.rs
+++ b/codespan-reporting/examples/custom_files.rs
@@ -12,7 +12,7 @@
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::term;
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
-use std::ops::Range;
+use core::ops::Range;
 
 fn main() -> anyhow::Result<()> {
     let mut files = files::Files::new();
@@ -42,7 +42,7 @@ fn main() -> anyhow::Result<()> {
 /// A module containing the file implementation
 mod files {
     use codespan_reporting::files;
-    use std::ops::Range;
+    use core::ops::Range;
 
     /// A file that is backed by an `Arc<String>`.
     #[derive(Debug, Clone)]
@@ -57,7 +57,7 @@ mod files {
 
     impl File {
         fn line_start(&self, line_index: usize) -> Result<usize, files::Error> {
-            use std::cmp::Ordering;
+            use core::cmp::Ordering;
 
             match line_index.cmp(&self.line_starts.len()) {
                 Ordering::Less => Ok(*self
@@ -95,7 +95,7 @@ mod files {
             name: impl Into<String>,
             source: impl Into<String>,
         ) -> Option<FileId> {
-            use std::convert::TryFrom;
+            use core::convert::TryFrom;
 
             let file_id = FileId(u32::try_from(self.files.len()).ok()?);
             let name = name.into();

--- a/codespan-reporting/examples/readme_preview.rs
+++ b/codespan-reporting/examples/readme_preview.rs
@@ -187,7 +187,7 @@ fn main() -> anyhow::Result<()> {
             )?;
         }
         Opts::Stderr { color } => {
-            let writer = StandardStream::stderr(color.into());
+            let writer = StandardStream::stderr(color);
             let config = codespan_reporting::term::Config::default();
             for diagnostic in &diagnostics {
                 term::emit(&mut writer.lock(), &config, &file, diagnostic)?;

--- a/codespan-reporting/examples/readme_preview.rs
+++ b/codespan-reporting/examples/readme_preview.rs
@@ -94,6 +94,7 @@ fn main() -> anyhow::Result<()> {
             let mut buffer = Vec::new();
             let mut writer = HtmlEscapeWriter::new(SvgWriter::new(&mut buffer));
             let config = codespan_reporting::term::Config {
+                #[cfg(feature = "termcolor")]
                 styles: codespan_reporting::term::Styles::with_blue(Color::Blue),
                 ..codespan_reporting::term::Config::default()
             };

--- a/codespan-reporting/examples/reusable_diagnostic.rs
+++ b/codespan-reporting/examples/reusable_diagnostic.rs
@@ -2,7 +2,7 @@ use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
 use codespan_reporting::term::{self};
-use std::ops::Range;
+use core::ops::Range;
 
 #[derive(Debug)]
 pub struct Opts {

--- a/codespan-reporting/examples/reusable_diagnostic.rs
+++ b/codespan-reporting/examples/reusable_diagnostic.rs
@@ -39,7 +39,7 @@ fn main() -> anyhow::Result<()> {
     ];
 
     let Opts { color } = parse_args()?;
-    let writer = StandardStream::stderr(color.into());
+    let writer = StandardStream::stderr(color);
     let config = codespan_reporting::term::Config::default();
     for diagnostic in errors.iter().map(Error::report) {
         term::emit(&mut writer.lock(), &config, &file, &diagnostic)?;

--- a/codespan-reporting/examples/term.rs
+++ b/codespan-reporting/examples/term.rs
@@ -165,7 +165,7 @@ fn main() -> anyhow::Result<()> {
             )]),
     ];
 
-    let writer = StandardStream::stderr(color.into());
+    let writer = StandardStream::stderr(color);
     let config = codespan_reporting::term::Config::default();
     for diagnostic in &diagnostics {
         term::emit(&mut writer.lock(), &config, &files, diagnostic)?;

--- a/codespan-reporting/src/diagnostic.rs
+++ b/codespan-reporting/src/diagnostic.rs
@@ -1,9 +1,13 @@
 //! Diagnostic data structures.
 
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::ops::Range;
+
 #[cfg(feature = "serialization")]
 use serde::{Deserialize, Serialize};
-use std::ops::Range;
-use std::string::ToString;
 
 /// A severity level for diagnostic messages.
 ///

--- a/codespan-reporting/src/diagnostic.rs
+++ b/codespan-reporting/src/diagnostic.rs
@@ -192,9 +192,12 @@ impl<FileId> Diagnostic<FileId> {
         self.labels.append(&mut labels);
         self
     }
-    
+
     /// Add some labels to the diagnostic.
-    pub fn with_labels_iter(mut self, labels: impl IntoIterator<Item = Label<FileId>>) -> Diagnostic<FileId> {
+    pub fn with_labels_iter(
+        mut self,
+        labels: impl IntoIterator<Item = Label<FileId>>,
+    ) -> Diagnostic<FileId> {
         self.labels.extend(labels);
         self
     }
@@ -210,9 +213,12 @@ impl<FileId> Diagnostic<FileId> {
         self.notes.append(&mut notes);
         self
     }
-    
+
     /// Add some notes to the diagnostic.
-    pub fn with_notes_iter(mut self, notes: impl IntoIterator<Item = String>) -> Diagnostic<FileId> {
+    pub fn with_notes_iter(
+        mut self,
+        notes: impl IntoIterator<Item = String>,
+    ) -> Diagnostic<FileId> {
         self.notes.extend(notes);
         self
     }

--- a/codespan-reporting/src/files.rs
+++ b/codespan-reporting/src/files.rs
@@ -23,7 +23,14 @@
 //!
 //! [`salsa`]: https://crates.io/crates/salsa
 
-use std::ops::Range;
+use alloc::vec::Vec;
+use core::ops::Range;
+
+#[cfg(feature = "std")]
+use std::error;
+
+#[cfg(not(feature = "std"))]
+use core::error;
 
 /// An enum representing an error that happened while looking up a file or a piece of content in that file.
 #[derive(Debug)]
@@ -40,17 +47,27 @@ pub enum Error {
     /// The given index is contained in the file, but is not a boundary of a UTF-8 code point.
     InvalidCharBoundary { given: usize },
     /// There was a error while doing IO.
+    #[cfg(feature = "std")]
     Io(std::io::Error),
+    /// There was a error during formatting.
+    FormatError,
 }
 
+#[cfg(feature = "std")]
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Error {
         Error::Io(err)
     }
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl From<core::fmt::Error> for Error {
+    fn from(_err: core::fmt::Error) -> Error {
+        Error::FormatError
+    }
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::FileMissing => write!(f, "file missing"),
             Error::IndexTooLarge { given, max } => {
@@ -63,14 +80,17 @@ impl std::fmt::Display for Error {
                 write!(f, "invalid column {}, maximum column {}", given, max)
             }
             Error::InvalidCharBoundary { .. } => write!(f, "index is not a code point boundary"),
+            #[cfg(feature = "std")]
             Error::Io(err) => write!(f, "{}", err),
+            Error::FormatError => write!(f, "formatting error"),
         }
     }
 }
 
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match &self {
+            #[cfg(feature = "std")]
             Error::Io(err) => Some(err),
             _ => None,
         }
@@ -87,7 +107,7 @@ pub trait Files<'a> {
     /// for rendering `diagnostic::Label`s in the corresponding source files.
     type FileId: 'a + Copy + PartialEq;
     /// The user-facing name of a file, to be displayed in diagnostics.
-    type Name: 'a + std::fmt::Display;
+    type Name: 'a + core::fmt::Display;
     /// The source code of a file.
     type Source: 'a + AsRef<str>;
 
@@ -204,7 +224,7 @@ pub struct Location {
 /// assert_eq!(files::column_index(source, 2..13, 2 + 12), 3);
 /// ```
 pub fn column_index(source: &str, line_range: Range<usize>, byte_index: usize) -> usize {
-    let end_index = std::cmp::min(byte_index, std::cmp::min(line_range.end, source.len()));
+    let end_index = core::cmp::min(byte_index, core::cmp::min(line_range.end, source.len()));
 
     (line_range.start..end_index)
         .filter(|byte_index| source.is_char_boundary(byte_index + 1))
@@ -249,7 +269,7 @@ pub fn column_index(source: &str, line_range: Range<usize>, byte_index: usize) -
 /// ```
 // NOTE: this is copied in `codespan::file::line_starts` and should be kept in sync.
 pub fn line_starts(source: &str) -> impl '_ + Iterator<Item = usize> {
-    std::iter::once(0).chain(source.match_indices('\n').map(|(i, _)| i + 1))
+    core::iter::once(0).chain(source.match_indices('\n').map(|(i, _)| i + 1))
 }
 
 /// A file database that contains a single source file.
@@ -272,7 +292,7 @@ pub struct SimpleFile<Name, Source> {
 
 impl<Name, Source> SimpleFile<Name, Source>
 where
-    Name: std::fmt::Display,
+    Name: core::fmt::Display,
     Source: AsRef<str>,
 {
     /// Create a new source file.
@@ -297,7 +317,7 @@ where
     /// Return the starting byte index of the line with the specified line index.
     /// Convenience method that already generates errors if necessary.
     fn line_start(&self, line_index: usize) -> Result<usize, Error> {
-        use std::cmp::Ordering;
+        use core::cmp::Ordering;
 
         match line_index.cmp(&self.line_starts.len()) {
             Ordering::Less => Ok(self
@@ -316,7 +336,7 @@ where
 
 impl<'a, Name, Source> Files<'a> for SimpleFile<Name, Source>
 where
-    Name: 'a + std::fmt::Display + Clone,
+    Name: 'a + core::fmt::Display + Clone,
     Source: 'a + AsRef<str>,
 {
     type FileId = ();
@@ -358,7 +378,7 @@ pub struct SimpleFiles<Name, Source> {
 
 impl<Name, Source> SimpleFiles<Name, Source>
 where
-    Name: std::fmt::Display,
+    Name: core::fmt::Display,
     Source: AsRef<str>,
 {
     /// Create a new files database.
@@ -382,7 +402,7 @@ where
 
 impl<'a, Name, Source> Files<'a> for SimpleFiles<Name, Source>
 where
-    Name: 'a + std::fmt::Display + Clone,
+    Name: 'a + core::fmt::Display + Clone,
     Source: 'a + AsRef<str>,
 {
     type FileId = usize;

--- a/codespan-reporting/src/lib.rs
+++ b/codespan-reporting/src/lib.rs
@@ -1,6 +1,12 @@
 //! Diagnostic reporting support for the codespan crate.
 
 #![forbid(unsafe_code)]
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod diagnostic;
 pub mod files;

--- a/codespan-reporting/src/term.rs
+++ b/codespan-reporting/src/term.rs
@@ -1,5 +1,6 @@
 //! Terminal back-end for emitting diagnostics.
 
+#[cfg(feature = "termcolor")]
 use termcolor::WriteColor;
 
 use crate::diagnostic::Diagnostic;
@@ -9,9 +10,13 @@ mod config;
 mod renderer;
 mod views;
 
+#[cfg(feature = "termcolor")]
 pub use termcolor;
 
-pub use self::config::{Chars, Config, DisplayStyle, Styles};
+pub use self::config::{Chars, Config, DisplayStyle};
+
+#[cfg(feature = "termcolor")]
+pub use self::config::Styles;
 
 /// Emit a diagnostic using the given writer, context, config, and files.
 ///
@@ -20,7 +25,8 @@ pub use self::config::{Chars, Config, DisplayStyle, Styles};
 /// * a file was changed so that it is too small to have an index
 /// * IO fails
 pub fn emit<'files, F: Files<'files>>(
-    writer: &mut dyn WriteColor,
+    #[cfg(feature = "termcolor")] writer: &mut dyn WriteColor,
+    #[cfg(all(not(feature = "termcolor"), feature = "std"))] writer: &mut dyn std::io::Write,
     config: &Config,
     files: &'files F,
     diagnostic: &Diagnostic<F::FileId>,
@@ -36,7 +42,7 @@ pub fn emit<'files, F: Files<'files>>(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "termcolor"))]
 mod tests {
     use super::*;
 

--- a/codespan-reporting/src/term.rs
+++ b/codespan-reporting/src/term.rs
@@ -27,6 +27,7 @@ pub use self::config::Styles;
 pub fn emit<'files, F: Files<'files>>(
     #[cfg(feature = "termcolor")] writer: &mut dyn WriteColor,
     #[cfg(all(not(feature = "termcolor"), feature = "std"))] writer: &mut dyn std::io::Write,
+    #[cfg(all(not(feature = "termcolor"), not(feature = "std")))] writer: &mut dyn core::fmt::Write,
     config: &Config,
     files: &'files F,
     diagnostic: &Diagnostic<F::FileId>,
@@ -44,6 +45,8 @@ pub fn emit<'files, F: Files<'files>>(
 
 #[cfg(all(test, feature = "termcolor"))]
 mod tests {
+    use alloc::{vec, vec::Vec};
+
     use super::*;
 
     use crate::diagnostic::Label;

--- a/codespan-reporting/src/term/config.rs
+++ b/codespan-reporting/src/term/config.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 
 #[cfg(feature = "termcolor")]
 use {

--- a/codespan-reporting/src/term/config.rs
+++ b/codespan-reporting/src/term/config.rs
@@ -1,6 +1,9 @@
-use termcolor::{Color, ColorSpec};
 
-use crate::diagnostic::{LabelStyle, Severity};
+#[cfg(feature = "termcolor")]
+use {
+    crate::diagnostic::{LabelStyle, Severity},
+    termcolor::{Color, ColorSpec},
+};
 
 /// Configures how a diagnostic is rendered.
 #[derive(Clone, Debug)]
@@ -14,6 +17,7 @@ pub struct Config {
     /// Defaults to: `4`.
     pub tab_width: usize,
     /// Styles to use when rendering the diagnostic.
+    #[cfg(feature = "termcolor")]
     pub styles: Styles,
     /// Characters to use when rendering the diagnostic.
     pub chars: Chars,
@@ -44,6 +48,7 @@ impl Default for Config {
         Config {
             display_style: DisplayStyle::Rich,
             tab_width: 4,
+            #[cfg(feature = "termcolor")]
             styles: Styles::default(),
             chars: Chars::default(),
             start_context_lines: 3,
@@ -93,6 +98,7 @@ pub enum DisplayStyle {
 }
 
 /// Styles to use when rendering the diagnostic.
+#[cfg(feature = "termcolor")]
 #[derive(Clone, Debug)]
 pub struct Styles {
     /// The style to use when rendering bug headers.
@@ -144,6 +150,7 @@ pub struct Styles {
     pub note_bullet: ColorSpec,
 }
 
+#[cfg(feature = "termcolor")]
 impl Styles {
     /// The style used to mark a header at a given severity.
     pub fn header(&self, severity: Severity) -> &ColorSpec {
@@ -194,6 +201,7 @@ impl Styles {
     }
 }
 
+#[cfg(feature = "termcolor")]
 impl Default for Styles {
     fn default() -> Styles {
         // Blue is really difficult to see on the standard windows command line

--- a/codespan-reporting/src/term/renderer.rs
+++ b/codespan-reporting/src/term/renderer.rs
@@ -225,6 +225,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     /// 10 │   │ muffin. Halvah croissant candy canes bonbon candy. Apple pie jelly
     ///    │ ╭─│─────────^
     /// ```
+    #[allow(clippy::too_many_arguments)]
     pub fn render_snippet_source(
         &mut self,
         outer_padding: usize,

--- a/codespan-reporting/src/term/renderer.rs
+++ b/codespan-reporting/src/term/renderer.rs
@@ -460,9 +460,10 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
                             #[cfg(feature = "termcolor")]
                             self.reset()?;
                         }
-                        Some(_label_style) => {
+                        #[cfg_attr(not(feature = "termcolor"), allow(unused))]
+                        Some(label_style) => {
                             #[cfg(feature = "termcolor")]
-                            self.set_color(self.styles().label(severity, _label_style))?;
+                            self.set_color(self.styles().label(severity, label_style))?;
                         }
                     }
                 }
@@ -487,10 +488,11 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
                 self.reset()?;
             }
             // Write first trailing label message
-            if let Some((_, (_label_style, _, message))) = trailing_label {
+            #[cfg_attr(not(feature = "termcolor"), allow(unused))]
+            if let Some((_, (label_style, _, message))) = trailing_label {
                 write!(self, " ")?;
                 #[cfg(feature = "termcolor")]
-                self.set_color(self.styles().label(severity, *_label_style))?;
+                self.set_color(self.styles().label(severity, *label_style))?;
                 write!(self, "{}", message)?;
                 #[cfg(feature = "termcolor")]
                 self.reset()?;
@@ -531,7 +533,8 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
                 //   │     first borrow later used by call
                 //   │     help: some help here
                 // ```
-                for (_label_style, range, message) in
+                #[cfg_attr(not(feature = "termcolor"), allow(unused))]
+                for (label_style, range, message) in
                     hanging_labels(single_labels, trailing_label).rev()
                 {
                     self.outer_gutter(outer_padding)?;
@@ -548,7 +551,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
                             .take_while(|(byte_index, _)| *byte_index < range.start),
                     )?;
                     #[cfg(feature = "termcolor")]
-                    self.set_color(self.styles().label(severity, *_label_style))?;
+                    self.set_color(self.styles().label(severity, *label_style))?;
                     write!(self, "{}", message)?;
                     #[cfg(feature = "termcolor")]
                     self.reset()?;
@@ -783,7 +786,7 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     /// Write vertical lines pointing to carets.
     fn caret_pointers(
         &mut self,
-        _severity: Severity,
+        #[cfg_attr(not(feature = "termcolor"), allow(unused))] severity: Severity,
         max_label_start: usize,
         single_labels: &[SingleLabel<'_>],
         trailing_label: Option<(usize, &SingleLabel<'_>)>,
@@ -798,9 +801,10 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
 
             let mut spaces = match label_style {
                 None => 0..metrics.unicode_width,
-                Some(_label_style) => {
+                #[cfg_attr(not(feature = "termcolor"), allow(unused))]
+                Some(label_style) => {
                     #[cfg(feature = "termcolor")]
-                    self.set_color(self.styles().label(_severity, _label_style))?;
+                    self.set_color(self.styles().label(severity, label_style))?;
                     write!(self, "{}", self.chars().pointer_left)?;
                     #[cfg(feature = "termcolor")]
                     self.reset()?;
@@ -823,23 +827,24 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     /// ```
     fn label_multi_left(
         &mut self,
-        _severity: Severity,
-        _label_style: LabelStyle,
+        #[cfg_attr(not(feature = "termcolor"), allow(unused))] severity: Severity,
+        #[cfg_attr(not(feature = "termcolor"), allow(unused))] label_style: LabelStyle,
         underline: Option<LabelStyle>,
     ) -> Result<(), Error> {
         match underline {
             None => write!(self, " ")?,
             // Continue an underline horizontally
-            Some(_label_style) => {
+            #[cfg_attr(not(feature = "termcolor"), allow(unused))]
+            Some(label_style) => {
                 #[cfg(feature = "termcolor")]
-                self.set_color(self.styles().label(_severity, _label_style))?;
+                self.set_color(self.styles().label(severity, label_style))?;
                 write!(self, "{}", self.chars().multi_top)?;
                 #[cfg(feature = "termcolor")]
                 self.reset()?;
             }
         }
         #[cfg(feature = "termcolor")]
-        self.set_color(self.styles().label(_severity, _label_style))?;
+        self.set_color(self.styles().label(severity, label_style))?;
         write!(self, "{}", self.chars().multi_left)?;
         #[cfg(feature = "termcolor")]
         self.reset()?;
@@ -853,12 +858,12 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     /// ```
     fn label_multi_top_left(
         &mut self,
-        _severity: Severity,
-        _label_style: LabelStyle,
+        #[cfg_attr(not(feature = "termcolor"), allow(unused))] severity: Severity,
+        #[cfg_attr(not(feature = "termcolor"), allow(unused))] label_style: LabelStyle,
     ) -> Result<(), Error> {
         write!(self, " ")?;
         #[cfg(feature = "termcolor")]
-        self.set_color(self.styles().label(_severity, _label_style))?;
+        self.set_color(self.styles().label(severity, label_style))?;
         write!(self, "{}", self.chars().multi_top_left)?;
         #[cfg(feature = "termcolor")]
         self.reset()?;
@@ -872,12 +877,12 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     /// ```
     fn label_multi_bottom_left(
         &mut self,
-        _severity: Severity,
-        _label_style: LabelStyle,
+        #[cfg_attr(not(feature = "termcolor"), allow(unused))] severity: Severity,
+        #[cfg_attr(not(feature = "termcolor"), allow(unused))] label_style: LabelStyle,
     ) -> Result<(), Error> {
         write!(self, " ")?;
         #[cfg(feature = "termcolor")]
-        self.set_color(self.styles().label(_severity, _label_style))?;
+        self.set_color(self.styles().label(severity, label_style))?;
         write!(self, "{}", self.chars().multi_bottom_left)?;
         #[cfg(feature = "termcolor")]
         self.reset()?;
@@ -891,13 +896,13 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     /// ```
     fn label_multi_top_caret(
         &mut self,
-        _severity: Severity,
+        #[cfg_attr(not(feature = "termcolor"), allow(unused))] severity: Severity,
         label_style: LabelStyle,
         source: &str,
         start: usize,
     ) -> Result<(), Error> {
         #[cfg(feature = "termcolor")]
-        self.set_color(self.styles().label(_severity, label_style))?;
+        self.set_color(self.styles().label(severity, label_style))?;
 
         for (metrics, _) in self
             .char_metrics(source.char_indices())
@@ -926,14 +931,14 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     /// ```
     fn label_multi_bottom_caret(
         &mut self,
-        _severity: Severity,
+        #[cfg_attr(not(feature = "termcolor"), allow(unused))] severity: Severity,
         label_style: LabelStyle,
         source: &str,
         start: usize,
         message: &str,
     ) -> Result<(), Error> {
         #[cfg(feature = "termcolor")]
-        self.set_color(self.styles().label(_severity, label_style))?;
+        self.set_color(self.styles().label(severity, label_style))?;
 
         for (metrics, _) in self
             .char_metrics(source.char_indices())
@@ -961,14 +966,15 @@ impl<'writer, 'config> Renderer<'writer, 'config> {
     /// Writes an empty gutter space, or continues an underline horizontally.
     fn inner_gutter_column(
         &mut self,
-        _severity: Severity,
+        #[cfg_attr(not(feature = "termcolor"), allow(unused))] severity: Severity,
         underline: Option<Underline>,
     ) -> Result<(), Error> {
         match underline {
             None => self.inner_gutter_space(),
-            Some((_label_style, vertical_bound)) => {
+            #[cfg_attr(not(feature = "termcolor"), allow(unused))]
+            Some((label_style, vertical_bound)) => {
                 #[cfg(feature = "termcolor")]
-                self.set_color(self.styles().label(_severity, _label_style))?;
+                self.set_color(self.styles().label(severity, label_style))?;
                 let ch = match vertical_bound {
                     VerticalBound::Top => self.config.chars.multi_top,
                     VerticalBound::Bottom => self.config.chars.multi_bottom,

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -6,11 +6,8 @@ use crate::term::renderer::{Locus, MultiLabel, Renderer, SingleLabel};
 use crate::term::Config;
 
 /// Calculate the number of decimal digits in `n`.
-// TODO: simplify after https://github.com/rust-lang/rust/issues/70887 resolves
 fn count_digits(n: usize) -> usize {
-    // Use a saturating_add because in that edge case the number of digits
-    // will not be changed.
-    (n.saturating_add(1) as f64).log10().ceil() as usize
+    n.ilog10() as usize + 1
 }
 
 /// Output a richly formatted diagnostic, with source code previews.

--- a/codespan-reporting/src/term/views.rs
+++ b/codespan-reporting/src/term/views.rs
@@ -1,4 +1,9 @@
-use std::ops::Range;
+use alloc::{
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
+use core::ops::Range;
 
 use crate::diagnostic::{Diagnostic, LabelStyle};
 use crate::files::{Error, Files, Location};
@@ -35,7 +40,7 @@ where
     where
         FileId: 'files,
     {
-        use std::collections::BTreeMap;
+        use alloc::collections::BTreeMap;
 
         struct LabeledFile<'diagnostic, FileId> {
             file_id: FileId,
@@ -67,7 +72,7 @@ where
 
         struct Line<'diagnostic> {
             number: usize,
-            range: std::ops::Range<usize>,
+            range: core::ops::Range<usize>,
             // TODO: How do we reuse these allocations?
             single_labels: Vec<SingleLabel<'diagnostic>>,
             multi_labels: Vec<(usize, LabelStyle, MultiLabel<'diagnostic>)>,
@@ -89,8 +94,8 @@ where
             let end_line_number = files.line_number(label.file_id, end_line_index)?;
             let end_line_range = files.line_range(label.file_id, end_line_index)?;
 
-            outer_padding = std::cmp::max(outer_padding, count_digits(start_line_number));
-            outer_padding = std::cmp::max(outer_padding, count_digits(end_line_number));
+            outer_padding = core::cmp::max(outer_padding, count_digits(start_line_number));
+            outer_padding = core::cmp::max(outer_padding, count_digits(end_line_number));
 
             // NOTE: This could be made more efficient by using an associative
             // data structure like a hashmap or B-tree,  but we use a vector to
@@ -249,7 +254,7 @@ where
                     let line_range = files.line_range(label.file_id, line_index)?;
                     let line_number = files.line_number(label.file_id, line_index)?;
 
-                    outer_padding = std::cmp::max(outer_padding, count_digits(line_number));
+                    outer_padding = core::cmp::max(outer_padding, count_digits(line_number));
 
                     let line = labeled_file.get_or_insert_line(line_index, line_range, line_number);
 

--- a/codespan-reporting/tests/support/mod.rs
+++ b/codespan-reporting/tests/support/mod.rs
@@ -15,17 +15,17 @@ pub struct TestData<'files, F: Files<'files>> {
 impl<'files, F: Files<'files>> TestData<'files, F> {
     fn emit<W: WriteColor>(&'files self, mut writer: W, config: &Config) -> W {
         for diagnostic in &self.diagnostics {
-            emit(&mut writer, config, &self.files, &diagnostic).unwrap();
+            emit(&mut writer, config, &self.files, diagnostic).unwrap();
         }
         writer
     }
 
     pub fn emit_color(&'files self, config: &Config) -> String {
-        self.emit(ColorBuffer::new(), &config).into_string()
+        self.emit(ColorBuffer::new(), config).into_string()
     }
 
     pub fn emit_no_color(&'files self, config: &Config) -> String {
-        let buffer = self.emit(Buffer::no_color(), &config);
+        let buffer = self.emit(Buffer::no_color(), config);
         String::from_utf8_lossy(buffer.as_slice()).into_owned()
     }
 }

--- a/codespan-reporting/tests/term.rs
+++ b/codespan-reporting/tests/term.rs
@@ -893,7 +893,7 @@ mod unicode_spans {
 
     lazy_static::lazy_static! {
         static ref TEST_DATA: TestData<'static, SimpleFile<&'static str, String>> = {
-            let moon_phases = format!("{}", r#"🐄🌑🐄🌒🐄🌓🐄🌔🐄🌕🐄🌖🐄🌗🐄🌘🐄"#);
+            let moon_phases = r#"🐄🌑🐄🌒🐄🌓🐄🌔🐄🌕🐄🌖🐄🌗🐄🌘🐄"#.to_string();
             let invalid_start = 1;
             let invalid_end = "🐄".len() - 1;
             assert_eq!(moon_phases.is_char_boundary(invalid_start), false);

--- a/codespan-reporting/tests/term.rs
+++ b/codespan-reporting/tests/term.rs
@@ -896,8 +896,8 @@ mod unicode_spans {
             let moon_phases = r#"🐄🌑🐄🌒🐄🌓🐄🌔🐄🌕🐄🌖🐄🌗🐄🌘🐄"#.to_string();
             let invalid_start = 1;
             let invalid_end = "🐄".len() - 1;
-            assert_eq!(moon_phases.is_char_boundary(invalid_start), false);
-            assert_eq!(moon_phases.is_char_boundary(invalid_end), false);
+            assert!(!moon_phases.is_char_boundary(invalid_start));
+            assert!(!moon_phases.is_char_boundary(invalid_end));
             assert_eq!("🐄".len(), 4);
             let file = SimpleFile::new(
                 "moon_jump.rs",

--- a/codespan/CHANGELOG.md
+++ b/codespan/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-The minimum supported rustc version is now `1.46.0` (was `1.40.0`).
+The minimum supported rustc version is now `1.67.0` (was `1.40.0`).
 This is because dependencies of `codespan-lsp` now require this Rust version.
 
 ### Fixed

--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -19,3 +19,8 @@ termcolor = "1"
 
 [features]
 serialization = ["serde", "codespan-reporting/serialization"]
+
+[lints.clippy]
+alloc_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"

--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -8,7 +8,7 @@ description = "Data structures for tracking locations in source code"
 homepage = "https://github.com/brendanzab/codespan"
 repository = "https://github.com/brendanzab/codespan"
 documentation = "https://docs.rs/codespan"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 codespan-reporting = { path = "../codespan-reporting", version = "0.11.1" }

--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -11,13 +11,16 @@ documentation = "https://docs.rs/codespan"
 edition = "2021"
 
 [dependencies]
-codespan-reporting = { path = "../codespan-reporting", version = "0.11.1" }
-serde = { version = "1", optional = true, features = ["derive"]}
+codespan-reporting = { path = "../codespan-reporting", version = "0.11.1", default-features = false }
+serde = { version = "1", default-features = false, optional = true, features = ["derive", "alloc"]}
 
 [dev-dependencies]
 termcolor = "1"
 
 [features]
+default = ["std", "termcolor"]
+std = ["codespan-reporting/std", "serde?/std"]
+termcolor = ["std", "codespan-reporting/termcolor"]
 serialization = ["serde", "codespan-reporting/serialization"]
 
 [lints.clippy]

--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -25,6 +25,11 @@ termcolor = ["std", "codespan-reporting/termcolor"]
 serialization = ["serde", "codespan-reporting/serialization"]
 
 [lints.clippy]
+# Certain items from `core` are re-exported in `alloc` and `std`, and likewise `alloc` has items
+# re-exported in `std`.
+# `core` is available on all platforms, `alloc` is available on almost all, and `std` is only
+# available on some.
+# These lints ensure we don't import from a "less available" crate without reason.
 alloc_instead_of_core = "warn"
 std_instead_of_alloc = "warn"
 std_instead_of_core = "warn"

--- a/codespan/Cargo.toml
+++ b/codespan/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/brendanzab/codespan"
 repository = "https://github.com/brendanzab/codespan"
 documentation = "https://docs.rs/codespan"
 edition = "2021"
+rust-version = "1.67"
 
 [dependencies]
 codespan-reporting = { path = "../codespan-reporting", version = "0.11.1", default-features = false }

--- a/codespan/src/file.rs
+++ b/codespan/src/file.rs
@@ -408,7 +408,7 @@ fn line_starts(source: &str) -> impl '_ + Iterator<Item = usize> {
 #[cfg(test)]
 mod test {
     use alloc::borrow::ToOwned;
-    
+
     use super::*;
 
     const TEST_SOURCE: &str = "foo\nbar\r\n\nbaz";

--- a/codespan/src/index.rs
+++ b/codespan/src/index.rs
@@ -13,7 +13,7 @@ pub type RawIndex = u32;
 pub type RawOffset = i64;
 
 /// A zero-indexed line offset into a source file
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub struct LineIndex(pub RawIndex);
 
@@ -33,12 +33,6 @@ impl LineIndex {
     /// Convert the index into a `usize`, for use in array indexing
     pub const fn to_usize(self) -> usize {
         self.0 as usize
-    }
-}
-
-impl Default for LineIndex {
-    fn default() -> LineIndex {
-        LineIndex(0)
     }
 }
 
@@ -83,15 +77,9 @@ impl fmt::Display for LineNumber {
 }
 
 /// A line offset in a source file
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub struct LineOffset(pub RawOffset);
-
-impl Default for LineOffset {
-    fn default() -> LineOffset {
-        LineOffset(0)
-    }
-}
 
 impl fmt::Debug for LineOffset {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -108,7 +96,7 @@ impl fmt::Display for LineOffset {
 }
 
 /// A zero-indexed column offset into a source file
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub struct ColumnIndex(pub RawIndex);
 
@@ -128,12 +116,6 @@ impl ColumnIndex {
     /// Convert the index into a `usize`, for use in array indexing
     pub const fn to_usize(self) -> usize {
         self.0 as usize
-    }
-}
-
-impl Default for ColumnIndex {
-    fn default() -> ColumnIndex {
-        ColumnIndex(0)
     }
 }
 
@@ -171,15 +153,9 @@ impl fmt::Display for ColumnNumber {
 }
 
 /// A column offset in a source file
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub struct ColumnOffset(pub RawOffset);
-
-impl Default for ColumnOffset {
-    fn default() -> ColumnOffset {
-        ColumnOffset(0)
-    }
-}
 
 impl fmt::Debug for ColumnOffset {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -196,7 +172,7 @@ impl fmt::Display for ColumnOffset {
 }
 
 /// A byte position in a source file.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
 pub struct ByteIndex(pub RawIndex);
 
@@ -204,12 +180,6 @@ impl ByteIndex {
     /// Convert the position into a `usize`, for use in array indexing
     pub const fn to_usize(self) -> usize {
         self.0 as usize
-    }
-}
-
-impl Default for ByteIndex {
-    fn default() -> ByteIndex {
-        ByteIndex(0)
     }
 }
 

--- a/codespan/src/index.rs
+++ b/codespan/src/index.rs
@@ -1,9 +1,10 @@
 //! Wrapper types that specify positions in a source file
 
+use core::fmt;
+use core::ops::{Add, AddAssign, Neg, Sub, SubAssign};
+
 #[cfg(feature = "serialization")]
 use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::ops::{Add, AddAssign, Neg, Sub, SubAssign};
 
 /// The raw, untyped index. We use a 32-bit integer here for space efficiency,
 /// assuming we won't be working with sources larger than 4GB.

--- a/codespan/src/lib.rs
+++ b/codespan/src/lib.rs
@@ -10,6 +10,12 @@
 //!   for use with `serde`
 
 #![forbid(unsafe_code)]
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+extern crate alloc;
 
 mod file;
 mod index;

--- a/codespan/src/span.rs
+++ b/codespan/src/span.rs
@@ -1,9 +1,10 @@
-#[cfg(feature = "serialization")]
-use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::ops::Range;
+use core::fmt;
+use core::ops::Range;
 
 use crate::{ByteIndex, RawIndex};
+
+#[cfg(feature = "serialization")]
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serialization", derive(Deserialize, Serialize))]
@@ -61,7 +62,7 @@ impl Span {
     /// assert_eq!(Span::merge(span1, span2), Span::new(0, 16));
     /// ```
     pub fn merge(self, other: Span) -> Span {
-        use std::cmp::{max, min};
+        use core::cmp::{max, min};
 
         let start = min(self.start, other.start);
         let end = max(self.end, other.end);

--- a/codespan/src/span.rs
+++ b/codespan/src/span.rs
@@ -40,6 +40,7 @@ impl Span {
     ///
     /// assert_eq!(span, Span::new(0, 5));
     /// ```
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Span {
         Span::new(0, s.len() as u32)
     }


### PR DESCRIPTION
# Objective

Add `no_std` support to `codespan-reporting`, allowing its use in initiatives such as [`wasm32v1-none` support in `wgpu`](https://github.com/gfx-rs/wgpu/issues/6826).

## Solution

- Feature-gated `termcolor`, as it does not have `no_std` support 
- Added `#![no_std]` to all 3 crates. Noting that `codespan-lsp` does _not_ have `no_std` support as `lsp-types` does not have`no_std` support.
- Added `std` and `termcolor` features to `codespan-reporting` and `codespan`, which are both enabled by default.
- Various minor changes as suggested by `clippy`

## Notes

This is my first time contributing to this project. I have attempted to split my changes into meaningful commits with descriptions as described in the `CONTRIBUTING.md` document. Please let me know if there's anything I can do to assist with reviewing and merging this PR.