### PR TITLE
Allow writing to &mut dyn WriteStyle

### DIFF
--- a/codespan-reporting/src/term/config.rs
+++ b/codespan-reporting/src/term/config.rs
@@ -308,7 +308,7 @@ pub mod styles {
 #[cfg(feature = "termcolor")]
 impl<T> super::renderer::WriteStyle for T
 where
-    T: termcolor::WriteColor,
+    T: termcolor::WriteColor + ?Sized,
 {
     fn set_header(
         &mut self,

--- a/codespan-reporting/src/term/renderer.rs
+++ b/codespan-reporting/src/term/renderer.rs
@@ -108,6 +108,84 @@ impl<W: GeneralWrite> WriteStyle for PlainWriter<W> {
     }
 }
 
+pub(crate) struct WriteStyleByRef<'a, W: ?Sized> {
+    w: &'a mut W,
+}
+
+impl<'a, W> WriteStyleByRef<'a, W>
+where
+    W: ?Sized,
+{
+    pub fn new(writer: &'a mut W) -> Self {
+        Self { w: writer }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a, W> std::io::Write for WriteStyleByRef<'a, W>
+where
+    W: std::io::Write + ?Sized,
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.w.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.w.flush()
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<'a, W> core::fmt::Write for WriteStyleByRef<'a, W>
+where
+    W: core::fmt::Write + ?Sized,
+{
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.w.write_str(s)
+    }
+
+    fn write_char(&mut self, c: char) -> core::fmt::Result {
+        self.w.write_char(c)
+    }
+
+    fn write_fmt(&mut self, args: core::fmt::Arguments<'_>) -> core::fmt::Result {
+        self.w.write_fmt(args)
+    }
+}
+
+impl<'a, W> WriteStyle for WriteStyleByRef<'a, W>
+where
+    W: WriteStyle + ?Sized,
+{
+    fn set_header(&mut self, severity: Severity) -> GeneralWriteResult {
+        self.w.set_header(severity)
+    }
+
+    fn set_header_message(&mut self) -> GeneralWriteResult {
+        self.w.set_header_message()
+    }
+
+    fn set_line_number(&mut self) -> GeneralWriteResult {
+        self.w.set_line_number()
+    }
+
+    fn set_note_bullet(&mut self) -> GeneralWriteResult {
+        self.w.set_note_bullet()
+    }
+
+    fn set_source_border(&mut self) -> GeneralWriteResult {
+        self.w.set_source_border()
+    }
+
+    fn set_label(&mut self, severity: Severity, label_style: LabelStyle) -> GeneralWriteResult {
+        self.w.set_label(severity, label_style)
+    }
+
+    fn reset(&mut self) -> GeneralWriteResult {
+        self.w.reset()
+    }
+}
+
 /// The 'location focus' of a source code snippet.
 pub struct Locus {
     /// The user-facing name of the file.


### PR DESCRIPTION
Example:

```rust
use codespan_reporting::diagnostic::{Diagnostic, Label};
use codespan_reporting::files::SimpleFiles;
use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
use codespan_reporting::term::{self, Config, WriteStyle};

fn main() {
    let writer = StandardStream::stderr(ColorChoice::Auto);
    repro(&mut writer.lock());
}

fn repro(stderr: &mut dyn WriteStyle) {
    let mut files = SimpleFiles::new();
    let file = files.add("-", "...");

    let mut diagnostic = Diagnostic::error().with_message("...");
    diagnostic.labels.push(Label {
        message: "...".to_owned(),
        ..Label::primary(file, 1..2)
    });

    let config = Config::default();
    let _ = term::emit_to_write_style(stderr, &config, &files, &diagnostic);
}
```

This used to work in codespan-reporting 0.12.0 (with 2 minor substitutions, `term::emit_to_write_style` -> `term::emit` and `term::WriteStyle` -> `term::termcolor::WriteColor`) but fails to compile in codespan-reporting 0.13.0 due to missing `?Sized` bounds.

```console
error[E0277]: the size for values of type `dyn WriteStyle` cannot be known at compilation time
  --> src/main.rs:22:39
   |
22 |     let _ = term::emit_to_write_style(stderr, &config, &files, &diagnostic);
   |             ------------------------- ^^^^^^ doesn't have a size known at compile-time
   |             |
   |             required by a bound introduced by this call
   |
   = help: the trait `Sized` is not implemented for `dyn WriteStyle`
note: required by an implicit `Sized` bound in `emit_to_write_style`
  --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/codespan-reporting-0.13.0/src/term/mod.rs:80:63
   |
80 | pub fn emit_to_write_style<'files, F: Files<'files> + ?Sized, W: WriteStyle>(
   |                                                               ^ required by the implicit `Sized` requirement on this type parameter in `emit_to_write_style`
```