### PR TITLE
Regenerate Cargo.lock with 0.13.0 versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "codespan"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "codespan-reporting",
  "serde",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "codespan-lsp"
-version = "0.11.1"
+version = "0.13.0"
 dependencies = [
  "codespan-reporting",
  "lsp-types",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -70,7 +70,7 @@ dependencies = [
  "rustyline",
  "serde",
  "termcolor",
- "unicode-width 0.2.1",
+ "unicode-width 0.2.2",
  "unindent",
 ]
 
@@ -589,9 +589,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unindent"


### PR DESCRIPTION
6a28ecfc6b44a84393a1e2c7240432855eaaa094 updated 3 Cargo.toml files, but did not check in the resulting change to Cargo.lock.